### PR TITLE
AN-1193 Add int8, uint, and uint64 types to serializer

### DIFF
--- a/gremlin-go/driver/graphBinary.go
+++ b/gremlin-go/driver/graphBinary.go
@@ -653,7 +653,7 @@ func (serializer *graphBinaryTypeSerializer) getType(val interface{}) (dataType,
 		return longType, nil
 	case int32, uint16:
 		return intType, nil
-	case int8, int16: // GraphBinary doesn't have a type for signed 1-byte integer, serializing int8 as Short instead.
+	case int8, int16: // GraphBinary doesn't have a type for signed 8-bit integer, serializing int8 as Short instead.
 		return shortType, nil
 	case uint8:
 		return byteType, nil

--- a/gremlin-go/driver/graphBinary.go
+++ b/gremlin-go/driver/graphBinary.go
@@ -282,6 +282,10 @@ func intWriter(value interface{}, buffer *bytes.Buffer, _ *graphBinaryTypeSerial
 }
 
 func shortWriter(value interface{}, buffer *bytes.Buffer, _ *graphBinaryTypeSerializer) ([]byte, error) {
+	switch v := value.(type) {
+	case int8:
+		value = int16(v)
+	}
 	err := binary.Write(buffer, binary.BigEndian, value.(int16))
 	return buffer.Bytes(), err
 }
@@ -315,10 +319,17 @@ func getSignedBytesFromBigInt(n *big.Int) []byte {
 // Format: {length}{value_0}...{value_n}
 func bigIntWriter(value interface{}, buffer *bytes.Buffer, _ *graphBinaryTypeSerializer) ([]byte, error) {
 	var v big.Int
-	if reflect.TypeOf(value).Kind() == reflect.Ptr {
-		v = *(value.(*big.Int))
-	} else {
-		v = value.(big.Int)
+	switch val := value.(type) {
+	case uint:
+		v = *(new(big.Int).SetUint64(uint64(val)))
+	case uint64:
+		v = *(new(big.Int).SetUint64(val))
+	default:
+		if reflect.TypeOf(value).Kind() == reflect.Ptr {
+			v = *(value.(*big.Int))
+		} else {
+			v = value.(big.Int)
+		}
 	}
 	signedBytes := getSignedBytesFromBigInt(&v)
 	err := binary.Write(buffer, binary.BigEndian, int32(len(signedBytes)))
@@ -636,13 +647,13 @@ func (serializer *graphBinaryTypeSerializer) getType(val interface{}) (dataType,
 		return bytecodeType, nil
 	case string:
 		return stringType, nil
-	case *big.Int:
+	case uint, uint64, *big.Int:
 		return bigIntegerType, nil
 	case int64, int, uint32:
 		return longType, nil
 	case int32, uint16:
 		return intType, nil
-	case int16:
+	case int8, int16: // GraphBinary doesn't have a type for signed 1-byte integer, serializing int8 as Short instead.
 		return shortType, nil
 	case uint8:
 		return byteType, nil

--- a/gremlin-go/driver/graphBinary_test.go
+++ b/gremlin-go/driver/graphBinary_test.go
@@ -155,7 +155,7 @@ func TestGraphBinaryV1(t *testing.T) {
 			assert.Nil(t, err)
 			res, err := readShort(&buf, &pos)
 			assert.Nil(t, err)
-			assert.Equal(t, source, int8(res.(int16)))
+			assert.Equal(t, int16(source), res)
 		})
 		t.Run("read-write long", func(t *testing.T) {
 			pos := 0
@@ -185,7 +185,17 @@ func TestGraphBinaryV1(t *testing.T) {
 			assert.Nil(t, err)
 			res, err := readBigInt(&buf, &pos)
 			assert.Nil(t, err)
-			assert.Equal(t, source, res.(*big.Int).Uint64())
+			assert.Equal(t, new(big.Int).SetUint64(source), res)
+		})
+		t.Run("read-write bigInt uint64", func(t *testing.T) {
+			pos := 0
+			var buffer bytes.Buffer
+			source := uint(123)
+			buf, err := bigIntWriter(source, &buffer, nil)
+			assert.Nil(t, err)
+			res, err := readBigInt(&buf, &pos)
+			assert.Nil(t, err)
+			assert.Equal(t, new(big.Int).SetUint64(uint64(source)), res)
 		})
 		t.Run("read-write list", func(t *testing.T) {
 			pos := 0

--- a/gremlin-go/driver/graphBinary_test.go
+++ b/gremlin-go/driver/graphBinary_test.go
@@ -147,6 +147,16 @@ func TestGraphBinaryV1(t *testing.T) {
 			assert.Nil(t, err)
 			assert.Equal(t, source, res)
 		})
+		t.Run("read-write short int8", func(t *testing.T) {
+			pos := 0
+			var buffer bytes.Buffer
+			source := int8(123)
+			buf, err := shortWriter(source, &buffer, nil)
+			assert.Nil(t, err)
+			res, err := readShort(&buf, &pos)
+			assert.Nil(t, err)
+			assert.Equal(t, source, int8(res.(int16)))
+		})
 		t.Run("read-write long", func(t *testing.T) {
 			pos := 0
 			var buffer bytes.Buffer
@@ -166,6 +176,16 @@ func TestGraphBinaryV1(t *testing.T) {
 			res, err := readBigInt(&buf, &pos)
 			assert.Nil(t, err)
 			assert.Equal(t, source, res)
+		})
+		t.Run("read-write bigInt uint64", func(t *testing.T) {
+			pos := 0
+			var buffer bytes.Buffer
+			source := uint64(123)
+			buf, err := bigIntWriter(source, &buffer, nil)
+			assert.Nil(t, err)
+			res, err := readBigInt(&buf, &pos)
+			assert.Nil(t, err)
+			assert.Equal(t, source, res.(*big.Int).Uint64())
 		})
 		t.Run("read-write list", func(t *testing.T) {
 			pos := 0


### PR DESCRIPTION
The `int8` is serialized as Short, given the Byte I/O spec is an unsigned 8-bit integer. Both `uint` and `uint64` are serialized as BigIntegers, since they won't fit into a long. 

Opening for quick reviews before PR into main TinkerPop repo. 