### PR TITLE
TINKERPOP-2765 Fix concurrency issue during script translation in the GremlinGroovyScriptEngine.

### DIFF
--- a/gremlin-server/src/test/java/org/apache/tinkerpop/gremlin/server/GremlinServerIntegrateTest.java
+++ b/gremlin-server/src/test/java/org/apache/tinkerpop/gremlin/server/GremlinServerIntegrateTest.java
@@ -1087,4 +1087,26 @@ public class GremlinServerIntegrateTest extends AbstractGremlinServerIntegration
             cluster.close();
         }
     }
+
+    /**
+     * Reproducer for TINKERPOP-2765 when run using the UnifiedChannelizer.
+     */
+    @Test
+    public void shouldHandleMultipleLambdaTranslationsInParallel() throws Exception {
+        final GraphTraversalSource g = traversal().withRemote(conf);
+
+        final CompletableFuture<Traversal<Object, Object>> firstRes = g.with("evaluationTimeout", 90000L).inject(1).sideEffect(Lambda.consumer("Thread.sleep(100)")).promise(Traversal::iterate);
+        final CompletableFuture<Traversal<Object, Object>> secondRes = g.with("evaluationTimeout", 90000L).inject(1).sideEffect(Lambda.consumer("Thread.sleep(100)")).promise(Traversal::iterate);
+        final CompletableFuture<Traversal<Object, Object>> thirdRes = g.with("evaluationTimeout", 90000L).inject(1).sideEffect(Lambda.consumer("Thread.sleep(100)")).promise(Traversal::iterate);
+
+        try {
+            firstRes.get();
+            secondRes.get();
+            thirdRes.get();
+        } catch (Exception ce) {
+            fail("An exception was not expected because the traversals are all valid.");
+        } finally {
+            g.close();
+        }
+    }
 }


### PR DESCRIPTION
A concurrency issue occurs when the GremlinGroovyScriptEngine is called from multiple threads to evaluate bytecode that contains lambdas. The default translator is not thread-safe which results in queries being interlaced with one another. This is fixed by creating a new instance of the translator per translation so that the translation process isn't interfered with.