### PR TITLE
TINKERPOP-2779: Setting Cucumber timeout to 10s for Floating Errors on Windows on GitHub Actions

### DIFF
--- a/gremlin-javascript/src/main/javascript/gremlin-javascript/test/cucumber/feature-steps.js
+++ b/gremlin-javascript/src/main/javascript/gremlin-javascript/test/cucumber/feature-steps.js
@@ -22,7 +22,9 @@
  */
 'use strict';
 
-const {Given, Then, When} = require('cucumber');
+const {Given, Then, When, setDefaultTimeout} = require('cucumber');
+// Setting Cucumber timeout to 10s for Floating Errors on Windows on GitHub Actions
+setDefaultTimeout(10 * 1000);
 const expect = require('chai').expect;
 const util = require('util');
 const gremlin = require('./gremlin').gremlin;


### PR DESCRIPTION
Temporary fix for the [TINKERPOP-2779](https://issues.apache.org/jira/browse/TINKERPOP-2779). 

Slowdown appears to be coming from the Gremlin Server that is spun up to run the Cucumber tests. On logging some information from the server, I was able to verify that the server receives and processes the Connected Component Traversal ([Link to log line](https://github.com/L0Lmaker/tinkerpop/runs/7755756716?check_suite_focus=true#step:4:11942)).

Breakdown of what happens in the order it happens:
1. Client sends traversal to the server from Cucumber Step (Note: Cucumber Steps currently have a default timeout of 5s).
2. Server receives the request and starts processing the traversal.
3. Slowdown on the Server causes traversal to be processed much longer than usual.
4. 5s threshold on Cucumber Step is passed and Cucumber fails the scenario with a timeout error.
5. Gremlin-JS on Windows Fails on GitHub Actions.

As of now, without any server changes, the only way to mitigate the occasional GitHub Actions failure for Gremlin-JS Windows would be to increase the Cucumber timeout to 10s. If there is anyone that has encountered similar issues and could add some information that would be helpful. [TINKERPOP-2779](https://issues.apache.org/jira/browse/TINKERPOP-2779) was created specifically with `gremlin-javascript` in mind. Since then, ConnectedComponent's occasional timeout failures have been observed in the `Gremlin Dotnet` Driver as well. I have created a new ticket ([TINKERPOP-2784](https://issues.apache.org/jira/browse/TINKERPOP-2784)) documenting specifics of the `Gremlin Server` issue to keep track of it.