### PR TITLE
Dockerize gremlin-console python-based integration tests.

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -169,6 +169,7 @@ jobs:
           distribution: 'temurin'
       - name: Build with Maven
         run: |
+          touch gremlin-python/.glv
           mvn clean install -pl -:gremlin-javascript,-:gremlin-python,-gremlin-dotnet,-:gremlin-dotnet-source,-:gremlin-dotnet-tests,-:gremlint -q -DskipTests -Dci
           mvn verify -pl :gremlin-console -DskipTests -DskipIntegrationTests=false
   javascript:

--- a/docs/src/dev/developer/development-environment.asciidoc
+++ b/docs/src/dev/developer/development-environment.asciidoc
@@ -191,10 +191,9 @@ which enables the "glv-python" Maven profile or in a more automated fashion simp
 `gremlin-python` module which will signify to Maven that the environment is Python-ready. The `.glv` file need not have
 any contents and is ignored by Git. A standard `mvn clean install` will then build `gremlin-python` in full.
 
-The build also requires Python to execute `gremlin-console` integration tests. The integration test is configured by a
-"console-integration-tests" Maven profile. This profile can be activated manually or can more simply piggy-back on
-the `.glv` file in `gremlin-python`. Note that unlike `gremlin-python` the tests are actually integration tests and
-therefore must be actively switched on with `-DskipIntegrationTests=false`:
+The `.glv` file in `gremlin-python` also activates the "console-integration-tests" Maven profile to run gremlin-console
+integration tests. Alternatively, this profile can be activated manually. Note that unlike `gremlin-python` the tests
+are actually integration tests and therefore must be actively switched on with `-DskipIntegrationTests=false`:
 
 [source,text]
 mvn clean install -pl gremlin-console -DskipIntegrationTests=false

--- a/gremlin-console/pom.xml
+++ b/gremlin-console/pom.xml
@@ -308,84 +308,6 @@ limitations under the License.
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-antrun-plugin</artifactId>
                         <executions>
-                            <execution>
-                                <id>create-python-reports-directory</id>
-                                <phase>initialize</phase>
-                                <goals>
-                                    <goal>run</goal>
-                                </goals>
-                                <configuration>
-                                    <skip>${skipIntegrationTests}</skip>
-                                    <target>
-                                        <mkdir dir="${project.build.directory}/python-reports"/>
-                                        <mkdir dir="${project.build.directory}/python/env"/>
-                                    </target>
-                                </configuration>
-                            </execution>
-                            <!-- copy files in python directory to target/python and run virtual env to sandbox python.
-                                 there is no need to "activate" the virtualenv because all calls to python occur
-                                 directly from bin/ -->
-                            <execution>
-                                <id>setup-py-env</id>
-                                <phase>process-resources</phase>
-                                <goals>
-                                    <goal>run</goal>
-                                </goals>
-                                <configuration>
-                                    <skip>${skipIntegrationTests}</skip>
-                                    <tasks>
-                                        <copy todir="${project.build.directory}/python">
-                                            <fileset dir="src/test/python"/>
-                                        </copy>
-                                        <exec dir="${project.build.directory}/python" executable="python3"
-                                              failonerror="true">
-                                            <arg line="--version"/>
-                                        </exec>
-                                        <exec dir="${project.build.directory}/python" executable="virtualenv"
-                                              failonerror="true">
-                                            <arg line="--version"/>
-                                        </exec>
-                                        <exec dir="${project.build.directory}/python" executable="virtualenv"
-                                              failonerror="true">
-                                            <arg line="--python=python3 env"/>
-                                        </exec>
-                                    </tasks>
-                                </configuration>
-                            </execution>
-                            <execution>
-                                <id>native-python-build</id>
-                                <phase>compile</phase>
-                                <goals>
-                                    <goal>run</goal>
-                                </goals>
-                                <configuration>
-                                    <skip>${skipIntegrationTests}</skip>
-                                    <target>
-                                        <exec executable="env/bin/python" dir="${project.build.directory}/python"
-                                              failonerror="true">
-                                            <env key="PYTHONPATH" value=""/>
-                                            <arg line="setup.py build --build-lib ${project.build.outputDirectory}/Lib"/>
-                                        </exec>
-                                    </target>
-                                </configuration>
-                            </execution>
-
-                            <execution>
-                                <id>copy-gremlinsh</id>
-                                <phase>pre-integration-test</phase>
-                                <goals>
-                                    <goal>run</goal>
-                                </goals>
-                                <configuration>
-                                    <skip>${skipIntegrationTests}</skip>
-                                    <tasks>
-                                        <copy todir="${project.build.directory}/python/gremlin-console">
-                                            <fileset dir="${project.build.directory}/apache-tinkerpop-gremlin-console-${project.version}-standalone"/>
-                                        </copy>
-                                    </tasks>
-                                </configuration>
-                            </execution>
-
                             <!--
                             use pytest to execute native python tests - output of xunit output is configured in setup.cfg.
                             must run on integration tests because package phase has to execute to get the console binaries
@@ -400,10 +322,14 @@ limitations under the License.
                                 <configuration>
                                     <skip>${skipIntegrationTests}</skip>
                                     <target>
-                                        <exec executable="env/bin/python" dir="${project.build.directory}/python"
-                                              failonerror="true">
-                                            <env key="PYTHONPATH" value=""/>
-                                            <arg line="setup.py test"/>
+                                        <exec executable="docker" failonerror="true">
+                                            <!-- This build command relies on Docker's caching mechanism to reduce the amount of times it is run. -->
+                                            <arg line="build -t gremlin-console-test:py3.8jre11 ./src/test/python/docker"/>
+                                        </exec>
+                                        <exec executable="docker" failonerror="true">
+                                            <arg line="run --rm --mount type=bind,src=${project.basedir}/src/test/python,dst=/console_app
+                                            --mount type=bind,src=${project.basedir}/target/apache-tinkerpop-gremlin-console-${project.version}-standalone,dst=/console_app/gremlin-console
+                                            gremlin-console-test:py3.8jre11"/>
                                         </exec>
                                     </target>
                                 </configuration>

--- a/gremlin-console/src/test/python/docker/Dockerfile
+++ b/gremlin-console/src/test/python/docker/Dockerfile
@@ -6,7 +6,7 @@
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
 #
-#  http://www.apache.org/licenses/LICENSE-2.0
+#   http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,
 # software distributed under the License is distributed on an
@@ -14,9 +14,11 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-[aliases]
-test=pytest
 
-[tool:pytest]
-addopts = --junitxml=./python-reports/TEST-native-python.xml
-norecursedirs = '.*', 'build', 'dist', 'CVS', '_darcs', '{arch}', '*.egg' lib lib64
+# Image used for running integration tests for gremlin-console.
+FROM python:3.8.12
+
+RUN apt-get update && apt-get install -y --no-install-recommends openjdk-11-jre && apt-get install dos2unix
+
+WORKDIR /console_app
+CMD bash -c "dos2unix ./gremlin-console/bin/gremlin.sh && python3 setup.py build && python3 setup.py test"


### PR DESCRIPTION
Enable gremlin-console python integration tests on GHA.

Python 3.8 is used for the image because the version of pytest used
isn't compatible with later versions of Python. Building our own Docker
image also allows for greater control over the version of Python and
Java used.

The location of the python test output was changed in order to fit
better with the bind mounted volume for Docker.
