### PR TITLE
Address docker pr comments

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -210,7 +210,7 @@ jobs:
         run: |
           touch gremlin-javascript/.glv
           mvn clean install -pl -:gremlin-python,-gremlin-dotnet,-:gremlin-dotnet-source,-:gremlin-dotnet-tests -q -DskipTests -Dci
-          mvn verify -pl :gremlin-javascript,:gremlint -DincludeNeo4j
+          mvn verify -pl :gremlin-javascript,:gremlint
   python:
     name: python
     timeout-minutes: 20
@@ -269,7 +269,7 @@ jobs:
           touch gremlin-dotnet/src/.glv
           touch gremlin-dotnet/test/.glv
           mvn clean install -pl -:gremlin-javascript,-:gremlin-python,-:gremlint -q -DskipTests -Dci
-          mvn verify -pl :gremlin-dotnet,:gremlin-dotnet-tests -P gremlin-dotnet -DincludeNeo4j
+          mvn verify -pl :gremlin-dotnet,:gremlin-dotnet-tests -P gremlin-dotnet
   neo4j-gremlin:
     name: neo4j-gremlin
     timeout-minutes: 20

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -197,12 +197,12 @@ jobs:
             ./gremlin-server/*
             ~/.m2/repository/org/apache/tinkerpop/*
           key: ${{ github.sha }}
-      - name: Download Server Base Image
-        if: matrix.os == 'windows-latest'
-        uses: actions/download-artifact@v3
-        with:
-          name: ${{ github.sha }}
-          path: ./gremlin-server
+#      - name: Download Server Base Image
+#        if: matrix.os == 'windows-latest'
+#        uses: actions/download-artifact@v3
+#        with:
+#          name: ${{ github.sha }}
+#          path: ./gremlin-server
       - name: Load Docker Image
         working-directory: ./gremlin-server
         run: docker load --input gremlin-server.tar

--- a/gremlin-dotnet/docker-compose.yml
+++ b/gremlin-dotnet/docker-compose.yml
@@ -41,7 +41,7 @@ services:
       interval: 30s
       timeout: 10s
       retries: 30
-      start_period: 1m
+      start_period: 30s
 
   gremlin-dotnet-integration-tests:
     container_name: gremlin-dotnet-integration-tests

--- a/gremlin-dotnet/docker-compose.yml
+++ b/gremlin-dotnet/docker-compose.yml
@@ -15,13 +15,13 @@
 #    specific language governing permissions and limitations
 #    under the License.
 
-version: "3.7"
+version: "3.8"
 
 services:
 
   gremlin-server-test-dotnet:
     container_name: gremlin-server-test-dotnet
-    image: tinkerpop:gremlin-server-test-${GREMLIN_SERVER}
+    image: tinkerpop/gremlin-server-test:${GREMLIN_SERVER}
     build:
       context: ../
       dockerfile: docker/gremlin-test-server/Dockerfile

--- a/gremlin-dotnet/docker-compose.yml
+++ b/gremlin-dotnet/docker-compose.yml
@@ -36,6 +36,12 @@ services:
       - ${HOME}/.groovy:/root/.groovy
       - ${HOME}/.m2:/root/.m2
       - ${ABS_PROJECT_HOME}/gremlin-test/target:/opt/gremlin-test
+    healthcheck:
+      test: [ "CMD-SHELL", "apk add curl && curl -f http://localhost:45940?gremlin=100-1" ]
+      interval: 30s
+      timeout: 10s
+      retries: 30
+      start_period: 1m
 
   gremlin-dotnet-integration-tests:
     container_name: gremlin-dotnet-integration-tests
@@ -49,8 +55,7 @@ services:
       - TEST_TRANSACTIONS=true
     working_dir: /gremlin-dotnet
     command: >
-      bash -c "apt-get update && apt-get install dos2unix && dos2unix ./gremlin-test-server/wait-for-server.sh
-      && ./gremlin-test-server/wait-for-server.sh gremlin-server-test-dotnet 45940 300 
-      && dotnet test ./Gremlin.Net.sln"
+      bash -c "dotnet test ./Gremlin.Net.sln"
     depends_on:
-      - gremlin-server-test-dotnet
+      gremlin-server-test-dotnet:
+        condition: service_healthy

--- a/gremlin-dotnet/test/pom.xml
+++ b/gremlin-dotnet/test/pom.xml
@@ -95,6 +95,7 @@ limitations under the License.
                                     <skip>${skipTests}</skip>
                                     <environmentVariables>
                                         <GREMLIN_SERVER>${project.version}</GREMLIN_SERVER>
+                                        <ABS_PROJECT_HOME>${project.basedir}/../</ABS_PROJECT_HOME>
                                         <!-- setting this env variable is needed to be cross-platform compatible -->
                                         <HOME>${user.home}</HOME>
                                     </environmentVariables>
@@ -115,13 +116,26 @@ limitations under the License.
                                 </goals>
                                 <configuration>
                                     <skip>${skipTests}</skip>
-                                    <environmentVariables>
-                                        <GREMLIN_SERVER>${project.version}</GREMLIN_SERVER>
-                                        <HOME>${user.home}</HOME>
-                                    </environmentVariables>
+                                    <!-- don't need to set env variables for container tear down -->
                                     <executable>docker-compose</executable>
                                     <arguments>
                                         <argument>down</argument>
+                                    </arguments>
+                                </configuration>
+                            </execution>
+                            <execution>
+                                <id>remove-dangling-images</id>
+                                <phase>integration-test</phase>
+                                <goals>
+                                    <goal>exec</goal>
+                                </goals>
+                                <configuration>
+                                    <skip>${skipTests}</skip>
+                                    <executable>docker</executable>
+                                    <arguments>
+                                        <argument>image</argument>
+                                        <argument>prune</argument>
+                                        <argument>-f</argument>
                                     </arguments>
                                 </configuration>
                             </execution>

--- a/gremlin-dotnet/test/pom.xml
+++ b/gremlin-dotnet/test/pom.xml
@@ -68,9 +68,9 @@ limitations under the License.
     </build>
 
     <profiles>
-        <!-- Test gremlin-dotnet javascript in Docker -->
+        <!-- Test gremlin-dotnet in Docker -->
         <profile>
-            <id>glv-dotnet</id>
+            <id>gremlin-dotnet</id>
             <activation>
                 <activeByDefault>false</activeByDefault>
                 <file>

--- a/gremlin-go/docker-compose.yml
+++ b/gremlin-go/docker-compose.yml
@@ -15,13 +15,13 @@
 #    specific language governing permissions and limitations
 #    under the License.
 
-version: "3.7"
+version: "3.8"
 
 services:
 
   gremlin-server-test:
     container_name: gremlin-server-test
-    image: tinkerpop:gremlin-server-test-${GREMLIN_SERVER}
+    image: tinkerpop/gremlin-server-test:${GREMLIN_SERVER}
     build:
       context: ../
       dockerfile: docker/gremlin-test-server/Dockerfile

--- a/gremlin-go/docker-compose.yml
+++ b/gremlin-go/docker-compose.yml
@@ -36,6 +36,12 @@ services:
       - ${HOME}/.groovy:/root/.groovy
       - ${HOME}/.m2:/root/.m2
       - ${ABS_PROJECT_HOME}/gremlin-test/target:/opt/gremlin-test
+    healthcheck:
+      test: [ "CMD-SHELL", "apk add curl && curl -f http://localhost:45940?gremlin=100-1" ]
+      interval: 30s
+      timeout: 10s
+      retries: 30
+      start_period: 1m
 
   gremlin-go-integration-tests:
     container_name: gremlin-go-integration-tests
@@ -54,9 +60,8 @@ services:
       - TEST_TRANSACTIONS=true
     working_dir: /go_app
     command: >
-      bash -c "apt-get update && apt-get install dos2unix && dos2unix ./gremlin-test-server/wait-for-server.sh
-      && ./gremlin-test-server/wait-for-server.sh gremlin-server-test 45940 300
-      && go install github.com/haveyoudebuggedit/gotestfmt/v2/cmd/gotestfmt@latest
+      bash -c "go install github.com/haveyoudebuggedit/gotestfmt/v2/cmd/gotestfmt@latest
       && go test -v -json ./... -race -covermode=atomic -coverprofile=\"coverage.out\" -coverpkg=./... | gotestfmt"
     depends_on:
-      - gremlin-server-test
+      gremlin-server-test:
+        condition: service_healthy

--- a/gremlin-go/docker-compose.yml
+++ b/gremlin-go/docker-compose.yml
@@ -41,7 +41,7 @@ services:
       interval: 30s
       timeout: 10s
       retries: 30
-      start_period: 1m
+      start_period: 30s
 
   gremlin-go-integration-tests:
     container_name: gremlin-go-integration-tests

--- a/gremlin-go/pom.xml
+++ b/gremlin-go/pom.xml
@@ -118,14 +118,26 @@ limitations under the License.
                                 </goals>
                                 <configuration>
                                     <skip>${skipTests}</skip>
-                                    <environmentVariables>
-                                        <GREMLIN_SERVER>${project.version}</GREMLIN_SERVER>
-                                        <ABS_PROJECT_HOME>${project.basedir}</ABS_PROJECT_HOME>
-                                        <HOME>${user.home}</HOME>
-                                    </environmentVariables>
+                                    <!-- don't need to set env variables for container tear down -->
                                     <executable>docker-compose</executable>
                                     <arguments>
                                         <argument>down</argument>
+                                    </arguments>
+                                </configuration>
+                            </execution>
+                            <execution>
+                                <id>remove-dangling-images</id>
+                                <phase>integration-test</phase>
+                                <goals>
+                                    <goal>exec</goal>
+                                </goals>
+                                <configuration>
+                                    <skip>${skipTests}</skip>
+                                    <executable>docker</executable>
+                                    <arguments>
+                                        <argument>image</argument>
+                                        <argument>prune</argument>
+                                        <argument>-f</argument>
                                     </arguments>
                                 </configuration>
                             </execution>

--- a/gremlin-javascript/pom.xml
+++ b/gremlin-javascript/pom.xml
@@ -94,6 +94,7 @@ limitations under the License.
                                     <skip>${skipTests}</skip>
                                     <environmentVariables>
                                         <GREMLIN_SERVER>${project.version}</GREMLIN_SERVER>
+                                        <ABS_PROJECT_HOME>${project.basedir}/../</ABS_PROJECT_HOME>
                                         <!-- setting this env variable is needed to be cross-platform compatible -->
                                         <HOME>${user.home}</HOME>
                                     </environmentVariables>
@@ -115,15 +116,28 @@ limitations under the License.
                                 </goals>
                                 <configuration>
                                     <skip>${skipTests}</skip>
-                                    <environmentVariables>
-                                        <GREMLIN_SERVER>${project.version}</GREMLIN_SERVER>
-                                        <HOME>${user.home}</HOME>
-                                    </environmentVariables>
+                                    <!-- don't need to set env variables for container tear down -->
                                     <executable>docker-compose</executable>
                                     <arguments>
                                         <argument>down</argument>
                                     </arguments>
                                     <workingDirectory>./src/main/javascript/gremlin-javascript</workingDirectory>
+                                </configuration>
+                            </execution>
+                            <execution>
+                                <id>remove-dangling-images</id>
+                                <phase>integration-test</phase>
+                                <goals>
+                                    <goal>exec</goal>
+                                </goals>
+                                <configuration>
+                                    <skip>${skipTests}</skip>
+                                    <executable>docker</executable>
+                                    <arguments>
+                                        <argument>image</argument>
+                                        <argument>prune</argument>
+                                        <argument>-f</argument>
+                                    </arguments>
                                 </configuration>
                             </execution>
                         </executions>

--- a/gremlin-javascript/pom.xml
+++ b/gremlin-javascript/pom.xml
@@ -71,10 +71,7 @@ limitations under the License.
         <profile>
             <id>glv-js</id>
             <activation>
-                <activeByDefault>false</activeByDefault>
-                <file>
-                    <exists>.glv</exists>
-                </file>
+                <activeByDefault>true</activeByDefault>
             </activation>
             <build>
                 <finalName>${project.artifactId}-${project.version}</finalName>

--- a/gremlin-javascript/src/main/javascript/gremlin-javascript/docker-compose.yml
+++ b/gremlin-javascript/src/main/javascript/gremlin-javascript/docker-compose.yml
@@ -36,6 +36,12 @@ services:
       - ${HOME}/.groovy:/root/.groovy
       - ${HOME}/.m2:/root/.m2
       - ${ABS_PROJECT_HOME}/gremlin-test/target:/opt/gremlin-test
+    healthcheck:
+      test: [ "CMD-SHELL", "apk add curl && curl -f http://localhost:45940?gremlin=100-1" ]
+      interval: 30s
+      timeout: 10s
+      retries: 30
+      start_period: 1m
 
   gremlin-js-integration-tests:
     container_name: gremlin-js-integration-tests
@@ -48,9 +54,8 @@ services:
       - DOCKER_ENVIRONMENT=true
     working_dir: /js_app
     command: >
-      bash -c "apt-get update && apt-get install dos2unix && dos2unix ./gremlin-test-server/wait-for-server.sh
-      && ./gremlin-test-server/wait-for-server.sh gremlin-server-test-js 45940 300 
-      && npm config set cache /tmp --global
+      bash -c "npm config set cache /tmp --global
       && npm ci && npm run test && npm run features-docker"
     depends_on:
-      - gremlin-server-test-js
+      gremlin-server-test-js:
+        condition: service_healthy

--- a/gremlin-javascript/src/main/javascript/gremlin-javascript/docker-compose.yml
+++ b/gremlin-javascript/src/main/javascript/gremlin-javascript/docker-compose.yml
@@ -15,13 +15,13 @@
 #    specific language governing permissions and limitations
 #    under the License.
 
-version: "3.7"
+version: "3.8"
 
 services:
 
   gremlin-server-test-js:
     container_name: gremlin-server-test-js
-    image: tinkerpop:gremlin-server-test-${GREMLIN_SERVER}
+    image: tinkerpop/gremlin-server-test:${GREMLIN_SERVER}
     build:
       context: ../../../../../
       dockerfile: docker/gremlin-test-server/Dockerfile

--- a/gremlin-javascript/src/main/javascript/gremlin-javascript/docker-compose.yml
+++ b/gremlin-javascript/src/main/javascript/gremlin-javascript/docker-compose.yml
@@ -41,7 +41,7 @@ services:
       interval: 30s
       timeout: 10s
       retries: 30
-      start_period: 1m
+      start_period: 30s
 
   gremlin-js-integration-tests:
     container_name: gremlin-js-integration-tests

--- a/gremlin-server/pom.xml
+++ b/gremlin-server/pom.xml
@@ -186,6 +186,22 @@ limitations under the License.
                             </arguments>
                         </configuration>
                     </execution>
+                    <execution>
+                        <id>remove-dangling-images</id>
+                        <phase>install</phase>
+                        <goals>
+                            <goal>exec</goal>
+                        </goals>
+                        <configuration>
+                            <skip>${skipImageBuild}</skip>
+                            <executable>docker</executable>
+                            <arguments>
+                                <argument>image</argument>
+                                <argument>prune</argument>
+                                <argument>-f</argument>
+                            </arguments>
+                        </configuration>
+                    </execution>
                 </executions>
             </plugin>
         </plugins>


### PR DESCRIPTION
Added health check, for which the downside will be the fact that there is no output logs for the health check. The only way to check for errors is via `docker inspect`.

Also added docker image prune for dangling images. By definition, `these images occur when a new build of an image takes the repo:tag away from the image ID, leaving it as <none>:<none> or untagged.`, I'd assume they are safe to remove after we've re-build the image. 