### PR TITLE
TINKERPOP-2814 Add configuration for SSL handshake timeout.

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -35,6 +35,7 @@ image::https://raw.githubusercontent.com/apache/tinkerpop/master/docs/static/ima
 * Dockerized all test environment for .NET, JavaScript, Python, Go, and Python-based tests for Console, and added Docker as a build requirement.
 * Async operations in .NET can now be cancelled. This however does not cancel work that is already happening on the server.
 * Bumped to `snakeyaml` 1.32 to fix security vulnerability.
+* Added timeout option for SSL handshake. Also, increased defaults for MAX_WAIT_FOR_CONNECTION and CONNECTION_SETUP_TIMEOUT_MILLIS.
 
 ==== Bugs
 

--- a/docs/src/reference/gremlin-variants.asciidoc
+++ b/docs/src/reference/gremlin-variants.asciidoc
@@ -304,7 +304,7 @@ The following table describes the various configuration options for the Gremlin 
 |connectionPool.maxInProcessPerConnection |The maximum number of in-flight requests that can occur on a connection. |4
 |connectionPool.maxSimultaneousUsagePerConnection |The maximum number of times that a connection can be borrowed from the pool simultaneously. |16
 |connectionPool.maxSize |The maximum size of a connection pool for a host. |8
-|connectionPool.maxWaitForConnection |The amount of time in milliseconds to wait for a new connection before timing out. |3000
+|connectionPool.maxWaitForConnection |The amount of time in milliseconds to wait for a new connection before timing out. |25000
 |connectionPool.maxWaitForClose |The amount of time in milliseconds to wait for pending messages to be returned from the server before closing the connection. |3000
 |connectionPool.minInProcessPerConnection |The minimum number of in-flight requests that can occur on a connection. |1
 |connectionPool.minSimultaneousUsagePerConnection |The maximum number of times that a connection can be borrowed from the pool simultaneously. |8
@@ -317,7 +317,8 @@ The following table describes the various configuration options for the Gremlin 
 |connectionPool.trustStore |File location for a SSL Certificate Chain to use when SSL is enabled. If this value is not provided and SSL is enabled, the default `TrustManager` will be used. |_none_
 |connectionPool.trustStorePassword |The password of the `trustStore` if it is password-protected |_none_
 |connectionPool.validationRequest |A script that is used to test server connectivity. A good script to use is one that evaluates quickly and returns no data. The default simply returns an empty string, but if a graph is required by a particular provider, a good traversal might be `g.inject()`. |_''_
-|connectionPool.connectionSetupTimeoutMillis | Duration of time in milliseconds provided for connection setup to complete which includes WebSocket protocol handshake and SSL handshake. |15000
+|connectionPool.connectionSetupTimeoutMillis | Duration of time in milliseconds provided for connection setup to complete which includes WebSocket protocol handshake and SSL handshake. |20000
+|connectionPool.sslHandshakeTimeoutMillis | Duration of time in milliseconds provided for the SSL handshake to complete. |15000
 |hosts |The list of hosts that the driver will connect to. |localhost
 |jaasEntry |Sets the `AuthProperties.Property.JAAS_ENTRY` properties for authentication to Gremlin Server. |_none_
 |nioPoolSize |Size of the pool for handling request/response operations. |available processors

--- a/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/Channelizer.java
+++ b/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/Channelizer.java
@@ -34,6 +34,7 @@ import io.netty.handler.codec.http.HttpObjectAggregator;
 import io.netty.handler.codec.http.websocketx.WebSocketVersion;
 import io.netty.handler.codec.http.websocketx.extensions.compression.WebSocketClientCompressionHandler;
 import io.netty.handler.ssl.SslContext;
+import io.netty.handler.ssl.SslHandler;
 import io.netty.handler.timeout.IdleStateHandler;
 
 import org.slf4j.Logger;
@@ -123,7 +124,9 @@ public interface Channelizer extends ChannelHandler {
             }
 
             if (sslCtx.isPresent()) {
-                pipeline.addLast(sslCtx.get().newHandler(socketChannel.alloc(), connection.getUri().getHost(), connection.getUri().getPort()));
+                SslHandler sslHandler = sslCtx.get().newHandler(socketChannel.alloc(), connection.getUri().getHost(), connection.getUri().getPort());
+                sslHandler.setHandshakeTimeoutMillis(cluster.getSslHandshakeTimeout());
+                pipeline.addLast(sslHandler);
             }
 
             configure(pipeline);

--- a/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/Connection.java
+++ b/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/Connection.java
@@ -59,14 +59,15 @@ final class Connection {
 
     public static final int MAX_IN_PROCESS = 4;
     public static final int MIN_IN_PROCESS = 1;
-    public static final int MAX_WAIT_FOR_CONNECTION = 16000;
+    public static final int MAX_WAIT_FOR_CONNECTION = 25000;
     public static final int MAX_WAIT_FOR_CLOSE = 3000;
     public static final int MAX_CONTENT_LENGTH = 65536;
 
     public static final int RECONNECT_INTERVAL = 1000;
     public static final int RESULT_ITERATION_BATCH_SIZE = 64;
     public static final long KEEP_ALIVE_INTERVAL = 180000;
-    public final static long CONNECTION_SETUP_TIMEOUT_MILLIS = 15000;
+    public final static long CONNECTION_SETUP_TIMEOUT_MILLIS = 20000;
+    public final static long SSL_HANDSHAKE_TIMEOUT_MILLIS = 15000;
 
     /**
      * When a {@code Connection} is borrowed from the pool, this number is incremented to indicate the number of

--- a/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/Settings.java
+++ b/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/Settings.java
@@ -243,6 +243,9 @@ final class Settings {
             if (connectionPoolConf.containsKey("connectionSetupTimeoutMillis"))
                 cpSettings.connectionSetupTimeoutMillis = connectionPoolConf.getLong("connectionSetupTimeoutMillis");
 
+            if (connectionPoolConf.containsKey("sslHandshakeTimeoutMillis"))
+                cpSettings.sslHandshakeTimeoutMillis = connectionPoolConf.getLong("sslHandshakeTimeoutMillis");
+
             settings.connectionPool = cpSettings;
         }
 
@@ -401,9 +404,20 @@ final class Settings {
          * complete by then.
          *
          * Note that this value should be greater that SSL handshake timeout defined in
-         * {@link io.netty.handler.ssl.SslHandler} since WebSocket handshake include SSL handshake.
+         * {@link io.netty.handler.ssl.SslHandler} since WebSocket handshake include SSL handshake. This value should be
+         * less than {@link ConnectionPoolSettings#maxWaitForConnection}.
          */
         public long connectionSetupTimeoutMillis = Connection.CONNECTION_SETUP_TIMEOUT_MILLIS;
+
+        /**
+         *
+         * Duration of time in milliseconds provided for the SSL handshake to complete. Beyond this duration an
+         * exception would be thrown if the handshake is not complete by then.
+         *
+         * Note that this value should be less than connection setup timeout defined by
+         * {@link ConnectionPoolSettings#connectionSetupTimeoutMillis}.
+         */
+        public long sslHandshakeTimeoutMillis = Connection.SSL_HANDSHAKE_TIMEOUT_MILLIS;
     }
 
     public static class SerializerSettings {

--- a/gremlin-driver/src/test/java/org/apache/tinkerpop/gremlin/driver/ClusterBuilderTest.java
+++ b/gremlin-driver/src/test/java/org/apache/tinkerpop/gremlin/driver/ClusterBuilderTest.java
@@ -63,6 +63,9 @@ public class ClusterBuilderTest {
                 {"nioPoolSize0", Cluster.build().nioPoolSize(0), "nioPoolSize must be greater than zero"},
                 {"nioPoolSizeNeg1", Cluster.build().nioPoolSize(-1), "nioPoolSize must be greater than zero"},
                 {"connectionSetupTimeoutMillis0", Cluster.build().connectionSetupTimeoutMillis(0), "connectionSetupTimeoutMillis must be greater than zero"},
+                {"connectionSetupTimeoutMillisLtMax", Cluster.build().connectionSetupTimeoutMillis(15000).maxWaitForConnection(1000), "maxWaitForConnection cannot be less than connectionSetupTimeoutMillis"},
+                {"sslHandshakeTimeoutMillisNeg1", Cluster.build().sslHandshakeTimeoutMillis(-1), "sslHandshakeTimeoutMillis must be greater than or equal to zero"},
+                {"sslHandshakeTimeoutMillisLtConnectionSetup", Cluster.build().sslHandshakeTimeoutMillis(15000).connectionSetupTimeoutMillis(10000), "connectionSetupTimeoutMillis cannot be less than sslHandshakeTimeoutMillis"},
                 {"workerPoolSize0", Cluster.build().workerPoolSize(0), "workerPoolSize must be greater than zero"},
                 {"workerPoolSizeNeg1", Cluster.build().workerPoolSize(-1), "workerPoolSize must be greater than zero"},
                 {"channelizer", Cluster.build().channelizer("MissingChannelizer"), "The channelizer specified [MissingChannelizer] could not be instantiated - it should be the fully qualified classname of a Channelizer implementation available on the classpath"}});

--- a/gremlin-driver/src/test/java/org/apache/tinkerpop/gremlin/driver/SettingsTest.java
+++ b/gremlin-driver/src/test/java/org/apache/tinkerpop/gremlin/driver/SettingsTest.java
@@ -69,6 +69,7 @@ public class SettingsTest {
         conf.setProperty("connectionPool.channelizer", "channelizer0");
         conf.setProperty("connectionPool.validationRequest", "g.inject()");
         conf.setProperty("connectionPool.connectionSetupTimeoutMillis", 15000);
+        conf.setProperty("connectionPool.sslHandshakeTimeoutMillis", 10000);
 
         final Settings settings = Settings.from(conf);
 
@@ -102,6 +103,7 @@ public class SettingsTest {
         assertEquals(800, settings.connectionPool.maxContentLength);
         assertEquals(900, settings.connectionPool.reconnectInterval);
         assertEquals(15000, settings.connectionPool.connectionSetupTimeoutMillis);
+        assertEquals(10000, settings.connectionPool.sslHandshakeTimeoutMillis);
         assertEquals(1100, settings.connectionPool.resultIterationBatchSize);
         assertEquals("channelizer0", settings.connectionPool.channelizer);
         assertEquals("g.inject()", settings.connectionPool.validationRequest);


### PR DESCRIPTION
Resolves https://issues.apache.org/jira/browse/TINKERPOP-2814

Note: The default timeouts were increased because they seem to be too low. This increase can be removed if it is deemed that the defaults shouldn't be changed in 3.5-dev.