### PR TITLE
Adds User Agent handling to server

### DIFF
--- a/gremlin-server/src/main/java/org/apache/tinkerpop/gremlin/server/Context.java
+++ b/gremlin-server/src/main/java/org/apache/tinkerpop/gremlin/server/Context.java
@@ -22,11 +22,14 @@ import org.apache.tinkerpop.gremlin.driver.Tokens;
 import org.apache.tinkerpop.gremlin.driver.message.RequestMessage;
 import org.apache.tinkerpop.gremlin.driver.message.ResponseMessage;
 import org.apache.tinkerpop.gremlin.driver.message.ResponseStatusCode;
+import org.apache.tinkerpop.gremlin.driver.util.UserAgent;
 import org.apache.tinkerpop.gremlin.groovy.engine.GremlinExecutor;
 import io.netty.channel.ChannelHandlerContext;
+import io.netty.util.AttributeKey;
 import org.apache.tinkerpop.gremlin.groovy.jsr223.GremlinScriptChecker;
 import org.apache.tinkerpop.gremlin.process.traversal.Bytecode;
 import org.apache.tinkerpop.gremlin.server.handler.Frame;
+import org.apache.tinkerpop.gremlin.server.handler.WsUserAgentHandler;
 import org.apache.tinkerpop.gremlin.structure.Graph;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -151,6 +154,15 @@ public class Context {
      */
     public GremlinExecutor getGremlinExecutor() {
         return gremlinExecutor;
+    }
+
+    /**
+     * Returns the user agent (if any) which was sent from the client during the web socket handshake.
+     * Returns empty string if no user agent exists
+     */
+    public String getUserAgent() {
+        return getChannelHandlerContext().channel().hasAttr(WsUserAgentHandler.USER_AGENT_ATTR_KEY) ?
+                getChannelHandlerContext().channel().attr(WsUserAgentHandler.USER_AGENT_ATTR_KEY).get() : "";
     }
 
     /**

--- a/gremlin-server/src/main/java/org/apache/tinkerpop/gremlin/server/channel/WebSocketChannelizer.java
+++ b/gremlin-server/src/main/java/org/apache/tinkerpop/gremlin/server/channel/WebSocketChannelizer.java
@@ -25,7 +25,6 @@ import org.apache.tinkerpop.gremlin.server.AbstractChannelizer;
 import org.apache.tinkerpop.gremlin.server.Channelizer;
 import org.apache.tinkerpop.gremlin.server.auth.AllowAllAuthenticator;
 import org.apache.tinkerpop.gremlin.server.handler.AbstractAuthenticationHandler;
-import org.apache.tinkerpop.gremlin.server.Settings;
 import org.apache.tinkerpop.gremlin.server.handler.WebSocketAuthorizationHandler;
 import org.apache.tinkerpop.gremlin.server.handler.SaslAuthenticationHandler;
 import org.apache.tinkerpop.gremlin.server.handler.WsGremlinBinaryRequestDecoder;
@@ -33,6 +32,8 @@ import org.apache.tinkerpop.gremlin.server.handler.WsGremlinCloseRequestDecoder;
 import org.apache.tinkerpop.gremlin.server.handler.GremlinResponseFrameEncoder;
 import org.apache.tinkerpop.gremlin.server.handler.WsGremlinResponseFrameEncoder;
 import org.apache.tinkerpop.gremlin.server.handler.WsGremlinTextRequestDecoder;
+import org.apache.tinkerpop.gremlin.server.handler.WsUserAgentHandler;
+import org.apache.tinkerpop.gremlin.server.Settings;
 import io.netty.channel.ChannelPipeline;
 import io.netty.handler.codec.http.HttpObjectAggregator;
 import io.netty.handler.codec.http.HttpRequestDecoder;
@@ -108,7 +109,7 @@ public class WebSocketChannelizer extends AbstractChannelizer {
                 closeOnProtocolViolation(false).allowExtensions(true).maxFramePayloadLength(settings.maxContentLength).build();
         pipeline.addLast(PIPELINE_REQUEST_HANDLER, new WebSocketServerProtocolHandler(GREMLIN_ENDPOINT,
                 null, false, false, 10000L, wsDecoderConfig));
-
+        pipeline.addLast("ws-user-agent-handler", new WsUserAgentHandler());
         if (logger.isDebugEnabled())
             pipeline.addLast(new LoggingHandler("log-aggregator-encoder", LogLevel.DEBUG));
 

--- a/gremlin-server/src/main/java/org/apache/tinkerpop/gremlin/server/handler/WsUserAgentHandler.java
+++ b/gremlin-server/src/main/java/org/apache/tinkerpop/gremlin/server/handler/WsUserAgentHandler.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.tinkerpop.gremlin.server.handler;
+
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelInboundHandlerAdapter;
+import io.netty.handler.codec.http.HttpHeaders;
+import io.netty.handler.codec.http.websocketx.WebSocketServerProtocolHandler;
+import io.netty.util.AttributeKey;
+import org.apache.tinkerpop.gremlin.driver.util.UserAgent;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Channel handler which extracts a user agent header from a web socket handshake if present
+ * then logs the user agent and stores it as a channel attribute for future reference.
+ */
+public class WsUserAgentHandler extends ChannelInboundHandlerAdapter {
+
+    private static final Logger logger = LoggerFactory.getLogger(WsUserAgentHandler.class);
+    public static final AttributeKey<String> USER_AGENT_ATTR_KEY = AttributeKey.valueOf(UserAgent.USER_AGENT_HEADER_NAME);
+
+    @Override
+    public void userEventTriggered(ChannelHandlerContext ctx, java.lang.Object evt){
+        if(evt instanceof WebSocketServerProtocolHandler.HandshakeComplete){
+            HttpHeaders requestHeaders = ((WebSocketServerProtocolHandler.HandshakeComplete) evt).requestHeaders();
+            if(requestHeaders.contains(UserAgent.USER_AGENT_HEADER_NAME)){
+                ctx.channel().attr(USER_AGENT_ATTR_KEY).set(requestHeaders.get(UserAgent.USER_AGENT_HEADER_NAME));
+                String message = String.format("New Connection on channel [%s] with user agent [%s]", ctx.channel().id().asShortText(), ctx.channel().attr(USER_AGENT_ATTR_KEY).get());
+                logger.info(message);
+            }
+            else{
+                logger.info("New Connection on channel [%s] with no user agent provided", ctx.channel().id().asShortText());
+            }
+        }
+        ctx.fireUserEventTriggered(evt);
+    }
+}

--- a/gremlin-server/src/test/java/org/apache/tinkerpop/gremlin/server/GremlinServerIntegrateTest.java
+++ b/gremlin-server/src/test/java/org/apache/tinkerpop/gremlin/server/GremlinServerIntegrateTest.java
@@ -18,11 +18,10 @@
  */
 package org.apache.tinkerpop.gremlin.server;
 
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.util.AttributeKey;
 import org.apache.commons.configuration2.BaseConfiguration;
 import org.apache.commons.configuration2.Configuration;
-import org.apache.tinkerpop.gremlin.server.channel.UnifiedChannelizer;
-import org.apache.tinkerpop.gremlin.server.channel.WebSocketChannelizer;
-import org.apache.tinkerpop.gremlin.util.ExceptionHelper;
 import org.apache.log4j.Level;
 import org.apache.log4j.Logger;
 import org.apache.tinkerpop.gremlin.TestHelper;
@@ -38,6 +37,7 @@ import org.apache.tinkerpop.gremlin.driver.message.ResponseStatusCode;
 import org.apache.tinkerpop.gremlin.driver.remote.DriverRemoteConnection;
 import org.apache.tinkerpop.gremlin.driver.ser.Serializers;
 import org.apache.tinkerpop.gremlin.driver.simple.SimpleClient;
+import org.apache.tinkerpop.gremlin.driver.util.UserAgent;
 import org.apache.tinkerpop.gremlin.groovy.jsr223.GremlinGroovyScriptEngine;
 import org.apache.tinkerpop.gremlin.groovy.jsr223.GroovyCompilerGremlinPlugin;
 import org.apache.tinkerpop.gremlin.groovy.jsr223.customizer.SimpleSandboxExtension;
@@ -50,11 +50,18 @@ import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.__;
 import org.apache.tinkerpop.gremlin.server.handler.OpSelectorHandler;
 import org.apache.tinkerpop.gremlin.server.op.AbstractEvalOpProcessor;
 import org.apache.tinkerpop.gremlin.server.op.standard.StandardOpProcessor;
+import org.apache.tinkerpop.gremlin.server.channel.TestChannelizer;
+import org.apache.tinkerpop.gremlin.server.channel.UnifiedChannelizer;
+import org.apache.tinkerpop.gremlin.server.channel.UnifiedTestChannelizer;
+import org.apache.tinkerpop.gremlin.server.channel.WebSocketChannelizer;
+import org.apache.tinkerpop.gremlin.server.channel.WebSocketTestChannelizer;
+import org.apache.tinkerpop.gremlin.server.handler.WsUserAgentHandler;
 import org.apache.tinkerpop.gremlin.structure.Graph;
 import org.apache.tinkerpop.gremlin.structure.T;
 import org.apache.tinkerpop.gremlin.structure.Vertex;
 import org.apache.tinkerpop.gremlin.util.Log4jRecordingAppender;
 import org.apache.tinkerpop.gremlin.util.function.Lambda;
+import org.apache.tinkerpop.gremlin.util.ExceptionHelper;
 import org.hamcrest.CoreMatchers;
 import org.hamcrest.Matchers;
 import org.junit.After;
@@ -127,12 +134,15 @@ public class GremlinServerIntegrateTest extends AbstractGremlinServerIntegration
         final Logger rootLogger = Logger.getRootLogger();
 
         if (name.getMethodName().equals("shouldPingChannelIfClientDies") ||
-                name.getMethodName().equals("shouldCloseChannelIfClientDoesntRespond")) {
+                name.getMethodName().equals("shouldCloseChannelIfClientDoesntRespond") ||
+                name.getMethodName().equals("shouldCaptureUserAgentFromClient")) {
             final org.apache.log4j.Logger opSelectorHandlerLogger = org.apache.log4j.Logger.getLogger(OpSelectorHandler.class);
             final org.apache.log4j.Logger unifiedHandlerLogger = org.apache.log4j.Logger.getLogger(UnifiedHandler.class);
+            final org.apache.log4j.Logger wsUserAgentHandlerLogger = org.apache.log4j.Logger.getLogger(WsUserAgentHandler.class);
             previousLogLevel = opSelectorHandlerLogger.getLevel();
             opSelectorHandlerLogger.setLevel(Level.INFO);
             unifiedHandlerLogger.setLevel(Level.INFO);
+            wsUserAgentHandlerLogger.setLevel(Level.INFO);
         }
 
         rootLogger.addAppender(recordingAppender);
@@ -143,11 +153,14 @@ public class GremlinServerIntegrateTest extends AbstractGremlinServerIntegration
         final Logger rootLogger = Logger.getRootLogger();
 
         if (name.getMethodName().equals("shouldPingChannelIfClientDies")||
-                name.getMethodName().equals("shouldCloseChannelIfClientDoesntRespond")) {
+                name.getMethodName().equals("shouldCloseChannelIfClientDoesntRespond") ||
+                name.getMethodName().equals("shouldCaptureUserAgentFromClient")) {
             final org.apache.log4j.Logger opSelectorHandlerLogger = org.apache.log4j.Logger.getLogger(OpSelectorHandler.class);
             opSelectorHandlerLogger.setLevel(previousLogLevel);
             final org.apache.log4j.Logger unifiedHandlerLogger = org.apache.log4j.Logger.getLogger(UnifiedHandler.class);
             unifiedHandlerLogger.setLevel(previousLogLevel);
+            final org.apache.log4j.Logger wsUserAgentHandlerLogger = org.apache.log4j.Logger.getLogger(WsUserAgentHandler.class);
+            wsUserAgentHandlerLogger.setLevel(previousLogLevel);
         }
 
         rootLogger.removeAppender(recordingAppender);
@@ -249,6 +262,12 @@ public class GremlinServerIntegrateTest extends AbstractGremlinServerIntegration
                 settings.gremlinPool = POOL_SIZE_FOR_TIMEOUT_TESTS;
                 settings.channelizer = UnifiedChannelizer.class.getName();
                 break;
+            case "shouldStoreUserAgentInContextWebSocket":
+                settings.channelizer = WebSocketTestChannelizer.class.getName();
+                break;
+            case "shouldStoreUserAgentInContextUnified":
+                settings.channelizer = UnifiedTestChannelizer.class.getName();
+                break;
             default:
                 break;
         }
@@ -281,6 +300,55 @@ public class GremlinServerIntegrateTest extends AbstractGremlinServerIntegration
         properties.put("ScriptBaseClass", BaseScriptForTesting.class.getName());
         scriptEngineConf.put("compilerConfigurationOptions", properties);
         return scriptEngineConf;
+    }
+
+    @Test
+    public void shouldCaptureUserAgentFromClient() {
+        final Cluster cluster = TestClientFactory.build().enableWsHandshakeUserAgent(true).create();
+        final Client client = cluster.connect();
+        client.submit("test");
+
+        assertThat(recordingAppender.logContainsAny(".*New Connection on channel .* with user agent.*$"), is(true));
+
+        cluster.close();
+    }
+
+    @Test
+    public void shouldStoreUserAgentInContextWebSocket() throws InterruptedException {
+        shouldStoreUserAgentInContext();
+    }
+
+    @Test
+    public void shouldStoreUserAgentInContextUnified() throws InterruptedException {
+        shouldStoreUserAgentInContext();
+    }
+
+    public void shouldStoreUserAgentInContext() throws InterruptedException {
+        if(server.getChannelizer() instanceof TestChannelizer) {
+            assertNull(getUserAgentIfAvailable());
+            final Cluster cluster = TestClientFactory.build().enableWsHandshakeUserAgent(true).create();
+            final Client client = cluster.connect();
+
+            client.submit("test");
+            assertEquals(UserAgent.WS_HANDSHAKE_USER_AGENT, getUserAgentIfAvailable());
+            client.submit("test");
+            assertEquals(UserAgent.WS_HANDSHAKE_USER_AGENT, getUserAgentIfAvailable());
+            client.close();
+            cluster.close();
+        }
+    }
+
+    private String getUserAgentIfAvailable() {
+        final AttributeKey<String> userAgentAttrKey = AttributeKey.valueOf(UserAgent.USER_AGENT_HEADER_NAME);
+        if(!(server.getChannelizer() instanceof TestChannelizer)) {
+            return null;
+        }
+        TestChannelizer channelizer = (TestChannelizer) server.getChannelizer();
+        ChannelHandlerContext ctx = channelizer.getMostRecentChannelHandlerContext();
+        if(ctx == null || !ctx.channel().hasAttr(userAgentAttrKey)) {
+            return null;
+        }
+        return channelizer.getMostRecentChannelHandlerContext().channel().attr(userAgentAttrKey).get();
     }
 
     @Test

--- a/gremlin-server/src/test/java/org/apache/tinkerpop/gremlin/server/channel/TestChannelizer.java
+++ b/gremlin-server/src/test/java/org/apache/tinkerpop/gremlin/server/channel/TestChannelizer.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.tinkerpop.gremlin.server.channel;
+
+import io.netty.channel.ChannelHandler;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelInboundHandlerAdapter;
+import org.apache.tinkerpop.gremlin.server.Channelizer;
+
+public interface TestChannelizer extends Channelizer {
+    public ChannelHandlerContext getMostRecentChannelHandlerContext();
+
+    @ChannelHandler.Sharable
+    class ContextHandler extends ChannelInboundHandlerAdapter {
+
+        private ChannelHandlerContext ctx;
+
+        @Override
+        public void channelRead(ChannelHandlerContext ctx, Object msg) throws Exception {
+            super.channelRead(ctx, msg);
+            this.ctx = ctx;
+        }
+
+        @Override
+        public void userEventTriggered(ChannelHandlerContext ctx, Object evt) throws Exception {
+            super.userEventTriggered(ctx, evt);
+            this.ctx = ctx;
+        }
+
+        public ChannelHandlerContext getMostRecentChannelHandlerContext() {
+            return this.ctx;
+        }
+    }
+}
+
+

--- a/gremlin-server/src/test/java/org/apache/tinkerpop/gremlin/server/channel/UnifiedTestChannelizer.java
+++ b/gremlin-server/src/test/java/org/apache/tinkerpop/gremlin/server/channel/UnifiedTestChannelizer.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.tinkerpop.gremlin.server.channel;
+
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelPipeline;
+
+/**
+ * A wrapper around UnifiedChannelizer which saves and exposes the ChannelHandlerContext for testing purposes
+ */
+public class UnifiedTestChannelizer extends UnifiedChannelizer implements TestChannelizer {
+
+    ContextHandler contextHandler;
+
+    public UnifiedTestChannelizer() {
+        contextHandler = new ContextHandler();
+    }
+
+    @Override
+    public void configure(ChannelPipeline pipeline) {
+        super.configure(pipeline);
+        pipeline.addLast(contextHandler);
+    }
+
+    public ChannelHandlerContext getMostRecentChannelHandlerContext() {
+        return contextHandler.getMostRecentChannelHandlerContext();
+    }
+}

--- a/gremlin-server/src/test/java/org/apache/tinkerpop/gremlin/server/channel/WebSocketTestChannelizer.java
+++ b/gremlin-server/src/test/java/org/apache/tinkerpop/gremlin/server/channel/WebSocketTestChannelizer.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.tinkerpop.gremlin.server.channel;
+
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelPipeline;
+
+/**
+ * A wrapper around WebSocketChannelizer which saves and exposes the ChannelHandlerContext for testing purposes
+ */
+public class WebSocketTestChannelizer extends WebSocketChannelizer implements TestChannelizer {
+
+    ContextHandler contextHandler;
+
+    public WebSocketTestChannelizer() {
+        contextHandler = new ContextHandler();
+    }
+
+    @Override
+    public void configure(ChannelPipeline pipeline) {
+        super.configure(pipeline);
+        pipeline.addLast(contextHandler);
+    }
+
+    public ChannelHandlerContext getMostRecentChannelHandlerContext() {
+        return contextHandler.getMostRecentChannelHandlerContext();
+    }
+}


### PR DESCRIPTION
Adds a new handler to WebSocketChannelizer which extracts a "User-Agent" header from a ws handshake if present, then logs the user agent and stores it as a channel attribute for future reference.