### PR TITLE
[TINKERPOP-2480] Adds Tests for User Agent in GLVs

### DIFF
--- a/gremlin-dotnet/src/Gremlin.Net/Process/Utils.cs
+++ b/gremlin-dotnet/src/Gremlin.Net/Process/Utils.cs
@@ -32,8 +32,11 @@ namespace Gremlin.Net.Process
     /// <summary>
     /// Contains useful methods that can be reused across the project. 
     /// </summary>
-    internal static class Utils
+    public static class Utils
     {
+        /// <summary>
+        /// The user agent which is sent with connection requests if enabled.
+        /// </summary>
         public static string UserAgent => _userAgent ??= GenerateUserAgent();
         private static string? _userAgent;
         

--- a/gremlin-javascript/src/main/javascript/gremlin-javascript/test/helper.js
+++ b/gremlin-javascript/src/main/javascript/gremlin-javascript/test/helper.js
@@ -78,11 +78,9 @@ exports.getSessionClient = function getSessionClient(traversalSource) {
   });
 };
 
-exports.getGremlinSocketServerClient = function getGremlinSocketServerClient(traversalSource) {
-  const settings = exports.getGremlinSocketServerSettings();
-  const url = socketServerUrl + settings.PORT + '/gremlin';
+function getMimeTypeFromSocketServerSettings(socketServerSettings) {
   let mimeType;
-  switch(settings.SERIALIZER) {
+  switch(socketServerSettings.SERIALIZER) {
     case "GraphSONV2":
       mimeType = 'application/vnd.gremlin-v2.0+json';
       break;
@@ -94,7 +92,21 @@ exports.getGremlinSocketServerClient = function getGremlinSocketServerClient(tra
       mimeType = 'application/vnd.graphbinary-v1.0';
       break;
   }
+  return mimeType;
+}
+
+exports.getGremlinSocketServerClient = function getGremlinSocketServerClient(traversalSource) {
+  const settings = exports.getGremlinSocketServerSettings();
+  const url = socketServerUrl + settings.PORT + '/gremlin';
+  let mimeType = getMimeTypeFromSocketServerSettings(settings)
   return new Client(url, { traversalSource, mimeType });
+};
+
+exports.getGremlinSocketServerClientNoUserAgent = function getGremlinSocketServerClient(traversalSource) {
+  const settings = exports.getGremlinSocketServerSettings();
+  const url = socketServerUrl + settings.PORT + '/gremlin';
+  let mimeType = getMimeTypeFromSocketServerSettings(settings)
+  return new Client(url, { traversalSource, mimeType, enableUserAgentOnConnect:false });
 };
 
 exports.getGremlinSocketServerSettings = function getGremlinSocketServerSettings() {

--- a/gremlin-javascript/src/main/javascript/gremlin-javascript/test/integration/client-behavior-tests.js
+++ b/gremlin-javascript/src/main/javascript/gremlin-javascript/test/integration/client-behavior-tests.js
@@ -21,6 +21,7 @@
 
 const assert = require('assert');
 const helper = require('../helper');
+const {getUserAgent} = require("../../lib/utils");
 
 let client;
 let settings;
@@ -48,6 +49,20 @@ describe('Client', function () {
             let result = await client.submit('1', null, {requestId: settings.SINGLE_VERTEX_REQUEST_ID})
             console.log("result received: "+JSON.stringify(result));
             assert.ok(result);
+        });
+        it('should include user agent in handshake request', async function () {
+            let result = await client.submit('1', null, {requestId: settings.USER_AGENT_REQUEST_ID});
+
+            assert.strictEqual(result.first(), getUserAgent());
+        });
+        it('should not include user agent in handshake request if disabled', async function () {
+            let noUserAgentClient = helper.getGremlinSocketServerClientNoUserAgent('gmodern');
+            let result = await noUserAgentClient.submit('1', null,
+                {requestId: settings.USER_AGENT_REQUEST_ID});
+
+            assert.strictEqual(result.first(), "");
+
+            await noUserAgentClient.close();
         });
     });
 });

--- a/gremlin-tools/gremlin-socket-server/src/main/java/org/apache/tinkerpop/gremlin/socket/server/TestWSGremlinInitializer.java
+++ b/gremlin-tools/gremlin-socket-server/src/main/java/org/apache/tinkerpop/gremlin/socket/server/TestWSGremlinInitializer.java
@@ -162,7 +162,10 @@ public class TestWSGremlinInitializer extends TestChannelizers.TestWebSocketServ
          * @throws SerializationException
          */
         private ByteBuf returnSimpleBinaryResponse(final UUID requestID, String message) throws SerializationException {
-            return SERIALIZER.serializeResponseAsBinary(ResponseMessage.build(requestID).result(message).create(), ByteBufAllocator.DEFAULT);
+            //Need to package message in a list of size 1 as some GLV's serializers require all messages to be in a list
+            final List<String> messageList = new ArrayList<>(1);
+            messageList.add(message);
+            return SERIALIZER.serializeResponseAsBinary(ResponseMessage.build(requestID).result(messageList).create(), ByteBufAllocator.DEFAULT);
         }
 
         /**


### PR DESCRIPTION
https://issues.apache.org/jira/browse/TINKERPOP-2480

This is my final PR for TINKERPOP-2480. It just adds a couple of simple tests in each GLV validating that the user agent is behaving correctly.