### PR TITLE
[TINKERPOP-2767] Fix server not handling StackOverflowError in bytecode traversals

### DIFF
--- a/gremlin-server/src/main/java/org/apache/tinkerpop/gremlin/server/handler/AbstractSession.java
+++ b/gremlin-server/src/main/java/org/apache/tinkerpop/gremlin/server/handler/AbstractSession.java
@@ -280,8 +280,8 @@ public abstract class AbstractSession implements Session, AutoCloseable {
 
             if (itty.isPresent())
                 handleIterator(sessionTask, itty.get());
-        } catch (Exception ex) {
-            handleException(sessionTask, ex);
+        } catch (Throwable t) {
+            handleException(sessionTask, t);
         } finally {
             timer.stop();
         }


### PR DESCRIPTION
https://issues.apache.org/jira/browse/TINKERPOP-2767

The existing error handling in TraversalOpProcessor and SessionOpProcessor during bytecode iteration was catching all exceptions sending an appropriate error response to the client. The OpProcessor however was not catching a StackOverflowError which could be induced by running a query which contains a large repeat step. This Error was being caught by FutureTask.run() but GremlinServer never wait's on this task or checks the results which caused this Error to be lost. A similar issue was found to exist in AbstractSession.process().

This PR adjusts the existing error handling code to catch any Throwable during bytecode iteration so clients will receive error messages and codes for server errors as well as exceptions. Any errors are re-thrown such that the evalFuture FutureTask will continue to have an exception set correctly (although GremlinServer currently does not use this for anything).