### PR TITLE
TINKERPOP-2830 Handle User-Agent from HTTP Requests to server

### DIFF
--- a/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/Channelizer.java
+++ b/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/Channelizer.java
@@ -268,7 +268,7 @@ public interface Channelizer extends ChannelHandler {
             if (connection.getClient() instanceof Client.SessionedClient)
                 throw new IllegalStateException(String.format("Cannot use sessions or tx() with %s", HttpChannelizer.class.getSimpleName()));
 
-            gremlinRequestEncoder = new HttpGremlinRequestEncoder(cluster.getSerializer(), cluster.getRequestInterceptor());
+            gremlinRequestEncoder = new HttpGremlinRequestEncoder(cluster.getSerializer(), cluster.getRequestInterceptor(), cluster.isUserAgentOnConnectEnabled());
             gremlinResponseDecoder = new HttpGremlinResponseDecoder(cluster.getSerializer());
         }
 
@@ -293,11 +293,6 @@ public interface Channelizer extends ChannelHandler {
                 throw new IllegalStateException("To use https scheme ensure that enableSsl is set to true in configuration");
 
             final int maxContentLength = cluster.connectionPoolSettings().maxContentLength;
-            final HttpHeaders httpHeaders = new DefaultHttpHeaders();
-            if(connection.getCluster().isUserAgentOnConnectEnabled()) {
-                httpHeaders.set(UserAgent.USER_AGENT_HEADER_NAME, UserAgent.USER_AGENT);
-            }
-
             handler = new HttpClientCodec();
 
             pipeline.addLast("http-codec", handler);

--- a/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/handler/HttpGremlinRequestEncoder.java
+++ b/gremlin-driver/src/main/java/org/apache/tinkerpop/gremlin/driver/handler/HttpGremlinRequestEncoder.java
@@ -27,8 +27,7 @@ import io.netty.handler.codec.http.FullHttpRequest;
 import io.netty.handler.codec.http.HttpHeaderNames;
 import io.netty.handler.codec.http.HttpMethod;
 import io.netty.handler.codec.http.HttpVersion;
-import org.apache.tinkerpop.gremlin.driver.MessageSerializer;
-import org.apache.tinkerpop.gremlin.driver.Tokens;
+import org.apache.tinkerpop.gremlin.driver.*;
 import org.apache.tinkerpop.gremlin.driver.exception.ResponseException;
 import org.apache.tinkerpop.gremlin.driver.message.RequestMessage;
 import org.apache.tinkerpop.gremlin.driver.message.ResponseStatusCode;
@@ -46,14 +45,22 @@ import java.util.function.UnaryOperator;
 @ChannelHandler.Sharable
 public final class HttpGremlinRequestEncoder extends MessageToMessageEncoder<RequestMessage> {
     private final MessageSerializer<?> serializer;
-
+    private final boolean userAgentEnabled;
     private static final ObjectMapper mapper = new ObjectMapper();
 
     private final UnaryOperator<FullHttpRequest> interceptor;
 
+    @Deprecated
     public HttpGremlinRequestEncoder(final MessageSerializer<?> serializer, final UnaryOperator<FullHttpRequest> interceptor) {
         this.serializer = serializer;
         this.interceptor = interceptor;
+        this.userAgentEnabled = true;
+    }
+
+    public HttpGremlinRequestEncoder(final MessageSerializer<?> serializer, final UnaryOperator<FullHttpRequest> interceptor, boolean userAgentEnabled) {
+        this.serializer = serializer;
+        this.interceptor = interceptor;
+        this.userAgentEnabled = userAgentEnabled;
     }
 
     @Override
@@ -81,7 +88,9 @@ public final class HttpGremlinRequestEncoder extends MessageToMessageEncoder<Req
             request.headers().add(HttpHeaderNames.CONTENT_TYPE, "application/json");
             request.headers().add(HttpHeaderNames.CONTENT_LENGTH, payload.length);
             request.headers().add(HttpHeaderNames.ACCEPT, serializer.mimeTypesSupported()[0]);
-
+            if (userAgentEnabled) {
+                request.headers().add(UserAgent.USER_AGENT_HEADER_NAME, UserAgent.USER_AGENT);
+            }
             objects.add(interceptor.apply(request));
         } catch (Exception ex) {
             throw new ResponseException(ResponseStatusCode.REQUEST_ERROR_SERIALIZATION, String.format(

--- a/gremlin-server/src/main/java/org/apache/tinkerpop/gremlin/server/AbstractChannelizer.java
+++ b/gremlin-server/src/main/java/org/apache/tinkerpop/gremlin/server/AbstractChannelizer.java
@@ -101,12 +101,12 @@ public abstract class AbstractChannelizer extends ChannelInitializer<SocketChann
     public static final String PIPELINE_HTTP_RESPONSE_ENCODER = "http-response-encoder";
     public static final String PIPELINE_HTTP_AGGREGATOR = "http-aggregator";
     public static final String PIPELINE_WEBSOCKET_SERVER_COMPRESSION = "web-socket-server-compression-handler";
+    public static final String PIPELINE_HTTP_USER_AGENT_HANDLER = "http-user-agent-handler";
 
     protected static final String PIPELINE_SSL = "ssl";
     protected static final String PIPELINE_OP_SELECTOR = "op-selector";
     protected static final String PIPELINE_OP_EXECUTOR = "op-executor";
     protected static final String PIPELINE_HTTP_REQUEST_DECODER = "http-request-decoder";
-
     protected static final String GREMLIN_ENDPOINT = "/gremlin";
 
     protected final Map<String, MessageSerializer<?>> serializers = new HashMap<>();

--- a/gremlin-server/src/main/java/org/apache/tinkerpop/gremlin/server/channel/HttpChannelizer.java
+++ b/gremlin-server/src/main/java/org/apache/tinkerpop/gremlin/server/channel/HttpChannelizer.java
@@ -26,6 +26,7 @@ import org.apache.tinkerpop.gremlin.server.auth.AllowAllAuthenticator;
 import org.apache.tinkerpop.gremlin.server.handler.AbstractAuthenticationHandler;
 import org.apache.tinkerpop.gremlin.server.handler.HttpBasicAuthenticationHandler;
 import org.apache.tinkerpop.gremlin.server.handler.HttpBasicAuthorizationHandler;
+import org.apache.tinkerpop.gremlin.server.handler.HttpUserAgentHandler;
 import org.apache.tinkerpop.gremlin.server.handler.HttpGremlinEndpointHandler;
 import io.netty.channel.ChannelPipeline;
 import io.netty.handler.codec.http.HttpObjectAggregator;
@@ -82,6 +83,7 @@ public class HttpChannelizer extends AbstractChannelizer {
             pipeline.addLast(PIPELINE_AUTHORIZER, authorizationHandler);
         }
 
+        pipeline.addLast("http-user-agent-handler", new HttpUserAgentHandler());
         pipeline.addLast("http-gremlin-handler", httpGremlinEndpointHandler);
     }
 

--- a/gremlin-server/src/main/java/org/apache/tinkerpop/gremlin/server/handler/HttpUserAgentHandler.java
+++ b/gremlin-server/src/main/java/org/apache/tinkerpop/gremlin/server/handler/HttpUserAgentHandler.java
@@ -47,8 +47,6 @@ public class HttpUserAgentHandler extends ChannelInboundHandlerAdapter {
 
     @Override
     public void channelRead(final ChannelHandlerContext ctx, Object msg) {
-//        if (msg instanceof HttpRequest) {
-//            final HttpRequest request = (HttpRequest) msg;
         if (msg instanceof FullHttpMessage) {
             final FullHttpMessage request = (FullHttpMessage) msg;
             if (request.headers().contains(UserAgent.USER_AGENT_HEADER_NAME)){

--- a/gremlin-server/src/main/java/org/apache/tinkerpop/gremlin/server/handler/HttpUserAgentHandler.java
+++ b/gremlin-server/src/main/java/org/apache/tinkerpop/gremlin/server/handler/HttpUserAgentHandler.java
@@ -1,0 +1,104 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.tinkerpop.gremlin.server.handler;
+
+import com.codahale.metrics.MetricRegistry;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelInboundHandlerAdapter;
+import io.netty.handler.codec.http.DefaultHttpRequest;
+import io.netty.handler.codec.http.FullHttpMessage;
+import io.netty.handler.codec.http.HttpHeaders;
+import io.netty.handler.codec.http.HttpRequest;
+import io.netty.handler.codec.http.websocketx.WebSocketServerProtocolHandler;
+import io.netty.util.AttributeKey;
+import org.apache.tinkerpop.gremlin.driver.UserAgent;
+import org.apache.tinkerpop.gremlin.server.GremlinServer;
+import org.apache.tinkerpop.gremlin.server.util.MetricManager;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import static org.apache.tinkerpop.gremlin.server.handler.HttpHandlerUtil.sendError;
+
+public class HttpUserAgentHandler extends ChannelInboundHandlerAdapter {
+    /**
+     * This constant caps the number of unique user agents which will be tracked in the metrics. Any new unique
+     * user agents will be replaced with "other" in the metrics after this cap has been reached.
+     */
+    private static final int MAX_USER_AGENT_METRICS = 10000;
+
+    private static final Logger logger = LoggerFactory.getLogger(WsUserAgentHandler.class);
+    public static final AttributeKey<String> USER_AGENT_ATTR_KEY = AttributeKey.valueOf(UserAgent.USER_AGENT_HEADER_NAME);
+
+    @Override
+    public void userEventTriggered(final ChannelHandlerContext ctx, java.lang.Object evt) {
+        if (evt instanceof FullHttpMessage) {
+            final FullHttpMessage request = (FullHttpMessage) evt;
+            if (!request.headers().contains("User-Agent")) {
+                return;
+            }
+            if (request.headers().contains(UserAgent.USER_AGENT_HEADER_NAME)){
+                final String userAgent = request.headers().get(UserAgent.USER_AGENT_HEADER_NAME);
+
+                ctx.channel().attr(USER_AGENT_ATTR_KEY).set(userAgent);
+                logger.debug("New Connection on channel [{}] with user agent [{}]", ctx.channel().id().asShortText(), userAgent);
+
+                String metricName = MetricRegistry.name(GremlinServer.class, "user-agent", userAgent);
+
+                // This check is to address a concern that an attacker may try to fill the server's memory with a very
+                // large number of unique user agents. For this reason the user agent is replaced with "other"
+                // for the purpose of metrics if this cap is ever exceeded and the user agent is not already being tracked.
+                if(MetricManager.INSTANCE.getCounterSize() > MAX_USER_AGENT_METRICS &&
+                        !MetricManager.INSTANCE.contains(metricName)) {
+                    metricName = MetricRegistry.name(GremlinServer.class, "user-agent", "other");
+                }
+                MetricManager.INSTANCE.getCounter(metricName).inc();
+            } else {
+                logger.debug("New Connection on channel [{}] with no user agent provided", ctx.channel().id().asShortText());
+            }
+        }
+        ctx.fireUserEventTriggered(evt);
+    }
+    @Override
+    public void channelRead(final ChannelHandlerContext ctx, Object msg) {
+//        if (msg instanceof HttpRequest) {
+//            final HttpRequest request = (HttpRequest) msg;
+        if (msg instanceof FullHttpMessage) {
+            final FullHttpMessage request = (FullHttpMessage) msg;
+            if (request.headers().contains(UserAgent.USER_AGENT_HEADER_NAME)){
+                final String userAgent = request.headers().get(UserAgent.USER_AGENT_HEADER_NAME);
+                ctx.channel().attr(USER_AGENT_ATTR_KEY).set(userAgent);
+                logger.debug("New Connection on channel [{}] with user agent [{}]", ctx.channel().id().asShortText(), userAgent);
+
+                String metricName = MetricRegistry.name(GremlinServer.class, "user-agent", userAgent);
+
+                // This check is to address a concern that an attacker may try to fill the server's memory with a very
+                // large number of unique user agents. For this reason the user agent is replaced with "other"
+                // for the purpose of metrics if this cap is ever exceeded and the user agent is not already being tracked.
+                if(MetricManager.INSTANCE.getCounterSize() > MAX_USER_AGENT_METRICS &&
+                        !MetricManager.INSTANCE.contains(metricName)) {
+                    metricName = MetricRegistry.name(GremlinServer.class, "user-agent", "other");
+                }
+                MetricManager.INSTANCE.getCounter(metricName).inc();
+            } else {
+                logger.debug("New Connection on channel [{}] with no user agent provided", ctx.channel().id().asShortText());
+            }
+        }
+        ctx.fireUserEventTriggered(msg);
+    }
+}

--- a/gremlin-server/src/main/java/org/apache/tinkerpop/gremlin/server/handler/WsAndHttpChannelizerHandler.java
+++ b/gremlin-server/src/main/java/org/apache/tinkerpop/gremlin/server/handler/WsAndHttpChannelizerHandler.java
@@ -29,6 +29,7 @@ import org.apache.tinkerpop.gremlin.server.channel.WsAndHttpChannelizer;
 import org.apache.tinkerpop.gremlin.server.util.ServerGremlinExecutor;
 
 import static org.apache.tinkerpop.gremlin.server.AbstractChannelizer.PIPELINE_HTTP_AGGREGATOR;
+import static org.apache.tinkerpop.gremlin.server.AbstractChannelizer.PIPELINE_HTTP_USER_AGENT_HANDLER;
 import static org.apache.tinkerpop.gremlin.server.channel.WebSocketChannelizer.PIPELINE_AUTHENTICATOR;
 import static org.apache.tinkerpop.gremlin.server.channel.WebSocketChannelizer.PIPELINE_REQUEST_HANDLER;
 
@@ -80,10 +81,12 @@ public class WsAndHttpChannelizerHandler extends ChannelInboundHandlerAdapter {
                 final ChannelHandler authenticator = pipeline.get(PIPELINE_AUTHENTICATOR);
                 pipeline.remove(PIPELINE_AUTHENTICATOR);
                 pipeline.addAfter(PIPELINE_HTTP_AGGREGATOR, PIPELINE_AUTHENTICATOR, authenticator);
-                pipeline.addAfter(PIPELINE_AUTHENTICATOR, PIPELINE_REQUEST_HANDLER, this.httpGremlinEndpointHandler);
+                pipeline.addAfter(PIPELINE_AUTHENTICATOR, PIPELINE_HTTP_USER_AGENT_HANDLER, new HttpUserAgentHandler());
+                pipeline.addAfter(PIPELINE_HTTP_USER_AGENT_HANDLER, PIPELINE_REQUEST_HANDLER, this.httpGremlinEndpointHandler);
             } else {
                 pipeline.remove(PIPELINE_REQUEST_HANDLER);
-                pipeline.addAfter(PIPELINE_HTTP_AGGREGATOR, PIPELINE_REQUEST_HANDLER, this.httpGremlinEndpointHandler);
+                pipeline.addAfter(PIPELINE_HTTP_AGGREGATOR, PIPELINE_HTTP_USER_AGENT_HANDLER, new HttpUserAgentHandler());
+                pipeline.addAfter(PIPELINE_HTTP_USER_AGENT_HANDLER, PIPELINE_REQUEST_HANDLER, this.httpGremlinEndpointHandler);
             }
         }
         ctx.fireChannelRead(obj);

--- a/gremlin-server/src/test/java/org/apache/tinkerpop/gremlin/server/GremlinServerIntegrateTest.java
+++ b/gremlin-server/src/test/java/org/apache/tinkerpop/gremlin/server/GremlinServerIntegrateTest.java
@@ -25,8 +25,7 @@ import io.netty.util.AttributeKey;
 import nl.altindag.log.LogCaptor;
 import org.apache.commons.configuration2.BaseConfiguration;
 import org.apache.commons.configuration2.Configuration;
-import org.apache.tinkerpop.gremlin.server.channel.UnifiedChannelizer;
-import org.apache.tinkerpop.gremlin.server.channel.WebSocketChannelizer;
+import org.apache.tinkerpop.gremlin.server.channel.*;
 import org.apache.tinkerpop.gremlin.util.ExceptionHelper;
 import org.apache.tinkerpop.gremlin.TestHelper;
 import org.apache.tinkerpop.gremlin.driver.Client;
@@ -54,11 +53,8 @@ import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversalSo
 import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.__;
 import org.apache.tinkerpop.gremlin.server.op.AbstractEvalOpProcessor;
 import org.apache.tinkerpop.gremlin.server.op.standard.StandardOpProcessor;
-import org.apache.tinkerpop.gremlin.server.channel.TestChannelizer;
 import org.apache.tinkerpop.gremlin.server.channel.UnifiedChannelizer;
-import org.apache.tinkerpop.gremlin.server.channel.UnifiedTestChannelizer;
 import org.apache.tinkerpop.gremlin.server.channel.WebSocketChannelizer;
-import org.apache.tinkerpop.gremlin.server.channel.WebSocketTestChannelizer;
 import org.apache.tinkerpop.gremlin.server.handler.WsUserAgentHandler;
 import org.apache.tinkerpop.gremlin.structure.Graph;
 import org.apache.tinkerpop.gremlin.structure.T;
@@ -275,6 +271,12 @@ public class GremlinServerIntegrateTest extends AbstractGremlinServerIntegration
             case "shouldStoreUserAgentInContextWebSocket":
                 settings.channelizer = WebSocketTestChannelizer.class.getName();
                 break;
+            case "shouldStoreUserAgentInContextHttp":
+                settings.channelizer = HttpTestChannelizer.class.getName();
+                break;
+            case "shouldStoreUserAgentInContextWsAndHttp":
+                settings.channelizer = WsAndHttpTestChannelizer.class.getName();
+                break;
             case "shouldStoreUserAgentInContextUnified":
                 settings.channelizer = UnifiedTestChannelizer.class.getName();
                 break;
@@ -330,12 +332,26 @@ public class GremlinServerIntegrateTest extends AbstractGremlinServerIntegration
     }
 
     @Test
+    public void shouldStoreUserAgentInContextHttp() throws InterruptedException {
+        shouldStoreUserAgentInHttpContext();
+    }
+
+    @Test
+    public void shouldStoreUserAgentInContextWsAndHttp() throws InterruptedException {
+        shouldStoreUserAgentInContext();
+        shouldStoreUserAgentInHttpContext();
+    }
+
+    @Test
     public void shouldStoreUserAgentInContextUnified() throws InterruptedException {
         shouldStoreUserAgentInContext();
+        shouldStoreUserAgentInHttpContext();
     }
 
     private void shouldStoreUserAgentInContext() throws InterruptedException {
         if(server.getChannelizer() instanceof TestChannelizer) {
+            TestChannelizer channelizer = (TestChannelizer) server.getChannelizer();
+            channelizer.resetChannelHandlerContext();
             assertNull(getUserAgentIfAvailable());
             final Cluster cluster = TestClientFactory.build().enableUserAgentOnConnect(true).create();
             final Client client = cluster.connect();
@@ -343,6 +359,28 @@ public class GremlinServerIntegrateTest extends AbstractGremlinServerIntegration
             client.submit("test");
             assertEquals(UserAgent.USER_AGENT, getUserAgentIfAvailable());
             client.submit("test");
+            assertEquals(UserAgent.USER_AGENT, getUserAgentIfAvailable());
+            client.close();
+            cluster.close();
+        }
+    }
+
+    private void shouldStoreUserAgentInHttpContext() throws InterruptedException {
+        if(server.getChannelizer() instanceof TestChannelizer) {
+            TestChannelizer channelizer = (TestChannelizer) server.getChannelizer();
+            channelizer.resetChannelHandlerContext();
+            assertNull(getUserAgentIfAvailable());
+            final Cluster cluster = TestClientFactory.build()
+                    .channelizer(org.apache.tinkerpop.gremlin.driver.Channelizer.HttpChannelizer.class)
+                    .enableUserAgentOnConnect(true)
+                    .create();
+            final Client client = cluster.connect();
+
+            client.submit("g.V()");
+            java.lang.Thread.sleep(1000);
+            assertEquals(UserAgent.USER_AGENT, getUserAgentIfAvailable());
+            client.submit("g.V()");
+            java.lang.Thread.sleep(1000);
             assertEquals(UserAgent.USER_AGENT, getUserAgentIfAvailable());
             client.close();
             cluster.close();

--- a/gremlin-server/src/test/java/org/apache/tinkerpop/gremlin/server/channel/HttpTestChannelizer.java
+++ b/gremlin-server/src/test/java/org/apache/tinkerpop/gremlin/server/channel/HttpTestChannelizer.java
@@ -22,22 +22,20 @@ import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelPipeline;
 
 /**
- * A wrapper around UnifiedChannelizer which saves and exposes the ChannelHandlerContext for testing purposes
+ * A wrapper around HttpChannelizer which saves and exposes the ChannelHandlerContext for testing purposes
  */
-public class
-
-UnifiedTestChannelizer extends UnifiedChannelizer implements TestChannelizer {
+public class HttpTestChannelizer extends HttpChannelizer implements TestChannelizer {
 
     final ContextHandler contextHandler;
 
-    public UnifiedTestChannelizer() {
+    public HttpTestChannelizer() {
         contextHandler = new ContextHandler();
     }
 
     @Override
     public void configure(final ChannelPipeline pipeline) {
         super.configure(pipeline);
-        pipeline.addLast(contextHandler);
+        pipeline.addFirst(contextHandler);
     }
 
     public ChannelHandlerContext getMostRecentChannelHandlerContext() {

--- a/gremlin-server/src/test/java/org/apache/tinkerpop/gremlin/server/channel/TestChannelizer.java
+++ b/gremlin-server/src/test/java/org/apache/tinkerpop/gremlin/server/channel/TestChannelizer.java
@@ -26,6 +26,8 @@ import org.apache.tinkerpop.gremlin.server.Channelizer;
 public interface TestChannelizer extends Channelizer {
     public ChannelHandlerContext getMostRecentChannelHandlerContext();
 
+    public void resetChannelHandlerContext();
+
     @ChannelHandler.Sharable
     class ContextHandler extends ChannelInboundHandlerAdapter {
 
@@ -45,6 +47,10 @@ public interface TestChannelizer extends Channelizer {
 
         public ChannelHandlerContext getMostRecentChannelHandlerContext() {
             return this.ctx;
+        }
+
+        public void resetChannelHandlerContext() {
+            this.ctx = null;
         }
     }
 }

--- a/gremlin-server/src/test/java/org/apache/tinkerpop/gremlin/server/channel/WebSocketTestChannelizer.java
+++ b/gremlin-server/src/test/java/org/apache/tinkerpop/gremlin/server/channel/WebSocketTestChannelizer.java
@@ -41,4 +41,8 @@ public class WebSocketTestChannelizer extends WebSocketChannelizer implements Te
     public ChannelHandlerContext getMostRecentChannelHandlerContext() {
         return contextHandler.getMostRecentChannelHandlerContext();
     }
+
+    public void resetChannelHandlerContext() {
+        contextHandler.resetChannelHandlerContext();
+    }
 }

--- a/gremlin-server/src/test/java/org/apache/tinkerpop/gremlin/server/channel/WsAndHttpTestChannelizer.java
+++ b/gremlin-server/src/test/java/org/apache/tinkerpop/gremlin/server/channel/WsAndHttpTestChannelizer.java
@@ -24,13 +24,11 @@ import io.netty.channel.ChannelPipeline;
 /**
  * A wrapper around UnifiedChannelizer which saves and exposes the ChannelHandlerContext for testing purposes
  */
-public class
-
-UnifiedTestChannelizer extends UnifiedChannelizer implements TestChannelizer {
+public class WsAndHttpTestChannelizer extends WsAndHttpChannelizer implements TestChannelizer {
 
     final ContextHandler contextHandler;
 
-    public UnifiedTestChannelizer() {
+    public WsAndHttpTestChannelizer() {
         contextHandler = new ContextHandler();
     }
 


### PR DESCRIPTION
Implemented user agent handler in server channelizer and tests for all channelizers that use http.  Additionally verified that python http requests are correctly handled.