### PR TITLE
TINKERPOP-3017 Added AnonymousTraversalSource.with()

### DIFF
--- a/docs/src/dev/provider/index.asciidoc
+++ b/docs/src/dev/provider/index.asciidoc
@@ -580,7 +580,7 @@ include::../../../../gremlin-dotnet/test/Gremlin.Net.IntegrationTest/Docs/Dev/Pr
 ==== RemoteConnection Implementations
 
 A `RemoteConnection` is an interface that is important for usage on traversal sources configured using the
-link:https://tinkerpop.apache.org/docs/x.y.z/reference/#connecting-via-drivers[withRemote()] option. A `Traversal`
+link:https://tinkerpop.apache.org/docs/x.y.z/reference/#connecting-via-drivers[with()] option. A `Traversal`
 that is generated from that source will apply a `RemoteStrategy` which will inject a `RemoteStep` to its end. That
 step will then send the `Bytecode` of the `Traversal` over the `RemoteConnection` to get the results that it will
 iterate.
@@ -1251,7 +1251,7 @@ To demonstrate consider this example:
 cluster = Cluster.open()
 client = cluster.connect()
 aliased = client.alias("g")
-g = traversal().withEmbedded(org.apache.tinkerpop.gremlin.structure.util.empty.EmptyGraph.instance())     <1>
+g = traversal().with(org.apache.tinkerpop.gremlin.structure.util.empty.EmptyGraph.instance())     <1>
 rs = aliased.submit(g.V().both().barrier().both().barrier()).all().get()                    <2>
 aliased.submit(g.V().both().barrier().both().barrier().count()).all().get().get(0).getInt() <3>
 rs.collect{[value: it.getObject().get(), bulk: it.getObject().bulk()]}                      <4>

--- a/docs/src/recipes/centrality.asciidoc
+++ b/docs/src/recipes/centrality.asciidoc
@@ -184,6 +184,6 @@ link:https://tinkerpop.apache.org/docs/x.y.z/reference/#pagerank-step[pageRank()
 
 [gremlin-groovy,modern]
 ----
-g = traversal().withEmbedded(graph).withComputer()
+g = traversal().with(graph).withComputer()
 g.V().pageRank().with(PageRank.propertyName,'pageRank').values('pageRank')
 ----

--- a/docs/src/recipes/olap-spark-yarn.asciidoc
+++ b/docs/src/recipes/olap-spark-yarn.asciidoc
@@ -105,7 +105,7 @@ conf.setProperty('spark.executor.extraLibraryPath', "$hadoop/lib/native:$hadoop/
 conf.setProperty('gremlin.spark.persistContext', 'true')
 hdfs.copyFromLocal('data/tinkerpop-modern.kryo', 'tinkerpop-modern.kryo')
 graph = GraphFactory.open(conf)
-g = traversal().withEmbedded(graph).withComputer(SparkGraphComputer)
+g = traversal().with(graph).withComputer(SparkGraphComputer)
 g.V().group().by(values('name')).by(both().count())
 ----
 

--- a/docs/src/reference/compilers.asciidoc
+++ b/docs/src/reference/compilers.asciidoc
@@ -67,7 +67,7 @@ may be used as follows:
 [gremlin-groovy,modern]
 ----
 graph = TinkerFactory.createModern()
-g = traversal(SparqlTraversalSource).withEmbedded(graph)                                               <1>
+g = traversal(SparqlTraversalSource).with(graph)                                                       <1>
 g.sparql("""SELECT ?name ?age
             WHERE { ?person v:name ?name . ?person v:age ?age }
             ORDER BY ASC(?age)""")                                                                     <2>
@@ -388,7 +388,7 @@ graph.
 
 [gremlin-groovy,theCrew]
 ----
-g = traversal(SparqlTraversalSource).withEmbedded(graph)
+g = traversal(SparqlTraversalSource).with(graph)
 g.sparql("""SELECT ?name ?startTime
 WHERE {
   ?person v:name "daniel" .
@@ -422,7 +422,7 @@ steps as shown below:
 
 [gremlin-groovy,modern]
 ----
-g = traversal(SparqlTraversalSource).withEmbedded(graph)
+g = traversal(SparqlTraversalSource).with(graph)
 g.sparql("SELECT ?name ?age WHERE { ?person v:name ?name . ?person v:age ?age }")
 g.sparql("SELECT ?name ?age WHERE { ?person v:name ?name . ?person v:age ?age }").select("name")
 g.sparql("SELECT * WHERE { }").out("knows").values("name")

--- a/docs/src/reference/gremlin-applications.asciidoc
+++ b/docs/src/reference/gremlin-applications.asciidoc
@@ -109,7 +109,7 @@ The "toy" graph provides a way to get started with Gremlin quickly.
 
 [gremlin-groovy]
 ----
-g = traversal().withEmbedded(TinkerFactory.createModern())
+g = traversal().with(TinkerFactory.createModern())
 g.V()
 g.V().values('name')
 g.V().has('name','marko').out('knows').values('name')
@@ -315,7 +315,7 @@ from the command line.  Consider the following file named `gremlin.groovy`:
 [source,groovy]
 ----
 graph = TinkerFactory.createModern()
-g = traversal().withEmbedded(graph)
+g = traversal().with(graph)
 g.V().each { println it }
 ----
 
@@ -341,7 +341,7 @@ to system out:
 [source,groovy]
 ----
 graph = TinkerFactory.createModern()
-g = traversal().withEmbedded(graph)
+g = traversal().with(graph)
 g.V().has('name',args[0]).each { println it }
 ----
 
@@ -381,7 +381,7 @@ graph might create a script called `init.groovy` like:
 [source,groovy]
 ----
 graph = TinkerFactory.createModern()
-g = traversal().withEmbedded(graph)
+g = traversal().with(graph)
 ----
 
 and then start Gremlin Console as follows:
@@ -569,7 +569,7 @@ params.put("name","marko");
 List<Result> list = client.submit("g.V().has('person','name',name).out('knows')", params).all().get();
 
 // bytecode
-GraphTraversalSource g = traversal().withRemote(DriverRemoteConnection.using("localhost",8182,"g"));
+GraphTraversalSource g = traversal().with(DriverRemoteConnection.using("localhost",8182,"g"));
 List<Vertex> list = g.V().has("person","name","marko").out("knows").toList();
 ----
 [source,groovy]
@@ -580,7 +580,7 @@ def client = cluster.connect()
 def list = client.submit("g.V().has('person','name',name).out('knows')", [name: "marko"]).all().get();
 
 // bytecode
-def g = traversal().withRemote(DriverRemoteConnection.using("localhost",8182,"g"))
+def g = traversal().with(DriverRemoteConnection.using("localhost",8182,"g"))
 def list = g.V().has('person','name','marko').out('knows').toList()
 ----
 [source,csharp]
@@ -595,7 +595,7 @@ const conn = client.open();
 const list = conn.submit("g.V().has('person','name',name).out('knows')",{name: 'marko'}).then(function (response) { ... });
 
 // bytecode
-const g = gtraversal().withRemote(new DriverRemoteConnection('ws://localhost:8182/gremlin'));
+const g = gtraversal().with(new DriverRemoteConnection('ws://localhost:8182/gremlin'));
 const list = g.V().has("person","name","marko").out("knows").toList();
 ----
 [source,python]
@@ -605,7 +605,7 @@ client = Client('ws://localhost:8182/gremlin', 'g')
 list = client.submit("g.V().has('person','name',name).out('knows')",{'name': 'marko'}).all()
 
 # bytecode
-g = traversal().withRemote(DriverRemoteConnection('ws://localhost:8182/gremlin','g'))
+g = traversal().with(DriverRemoteConnection('ws://localhost:8182/gremlin','g'))
 list = g.V().has("person","name","marko").out("knows").toList()
 ----
 [source,go]
@@ -618,7 +618,7 @@ result, err := resultSet.All()
 
 // bytecode
 remote, err := NewDriverRemoteConnection("ws://localhost:8182/gremlin")
-g := Traversal_().WithRemote(remote)
+g := Traversal_().With(remote)
 list, err := g.V().Has("person", "name", "marko").Out("knows").ToList()
 ----
 
@@ -1131,7 +1131,7 @@ method for processing script evaluation requests.
 [[traversalopprocessor]]
 ===== TraversalOpProcessor
 
-The `TraversalOpProcessor` provides a way to accept traversals configured via <<connecting-via-drivers,withRemote()>>.
+The `TraversalOpProcessor` provides a way to accept traversals configured via <<connecting-via-drivers,with()>>.
 It has no special configuration settings.
 
 ==== Serialization
@@ -1543,7 +1543,7 @@ Please see the example usage as follows:
 ----
 graph = TinkerGraph.open()
 graph.createIndex("username",Vertex.class)
-credentials = traversal(CredentialTraversalSource.class).withEmbedded(graph)
+credentials = traversal(CredentialTraversalSource.class).with(graph)
 credentials.user("stephen","password")
 credentials.user("daniel","better-password")
 credentials.user("marko","rainbow-dash")
@@ -2365,7 +2365,7 @@ included. The relevant configuration from the Gremlin Server initialization scri
 
 [source,groovy]
 ----
-globals << [g : traversal().withEmbedded(graph).withStrategies(ReferenceElementStrategy)]
+globals << [g : traversal().with(graph).withStrategies(ReferenceElementStrategy)]
 ----
 
 This configuration is global to Gremlin Server and therefore all methods of connection will always return elements
@@ -2382,7 +2382,7 @@ Cluster cluster = Cluster.open();
 Client client = cluster.connect();
 ResultSet results = client.submit("g.V().hasLabel('person').elementMap('name')");
 
-GraphTraversalSource g = traversal().withRemote('conf/remote-graph.properties');
+GraphTraversalSource g = traversal().with('conf/remote-graph.properties');
 List<Vertex> results = g.V().hasLabel("person").elementMap('name').toList();
 ----
 

--- a/docs/src/reference/gremlin-variants.asciidoc
+++ b/docs/src/reference/gremlin-variants.asciidoc
@@ -92,7 +92,7 @@ creating a `GraphTraversalSource`. A `GraphTraversalSource` is created from the 
 [source,go]
 ----
 remote, err := gremlingo.NewDriverRemoteConnection("ws://localhost:8182/gremlin")
-g := gremlingo.Traversal_().WithRemote(remote)
+g := gremlingo.Traversal_().With(remote)
 ----
 
 If you need to additional parameters to connection setup, you can pass in a configuration function.
@@ -210,7 +210,7 @@ builds on that content by demonstrating the transactional syntax for Go.
 [source,go]
 ----
 remote, err := NewDriverRemoteConnection("ws://localhost:8182/gremlin")
-g := gremlingo.Traversal_().WithRemote(remote)
+g := gremlingo.Traversal_().With(remote)
 
 // Create a Transaction.
 tx := g.Tx()
@@ -442,7 +442,7 @@ driverRemoteConnection, _ := gremlingo.NewDriverRemoteConnection("ws://localhost
 defer driverRemoteConnection.Close()
 
 // Create social traversal source from graph traversal source.
-social := &socialTraversalSource{gremlingo.Traversal_().WithRemote(driverRemoteConnection)}
+social := &socialTraversalSource{gremlingo.Traversal_().With(driverRemoteConnection)}
 
 // We can now use the social traversal source as well as traversal steps
 resBool, _ := social.persons("marko", "stephen").knows("josh").HasNext()
@@ -645,7 +645,7 @@ to creating a `GraphTraversalSource`. For <<connecting-embedded,embedded>> mode,
 [source,java]
 ----
 Graph graph = ...;
-GraphTraversalSource g = traversal().withEmbedded(graph);
+GraphTraversalSource g = traversal().with(graph);
 ----
 
 Using "g" it is then possible to start writing Gremlin. The "g" allows for the setting of many configuration options
@@ -659,14 +659,14 @@ are provided as follows:
 
 [source,java]
 ----
-GraphTraversalSource g = traversal().withRemote(DriverRemoteConnection.using("localhost",8182,"g"));
+GraphTraversalSource g = traversal().with(DriverRemoteConnection.using("localhost",8182,"g"));
 ----
 
 It is also possible to create it from a configuration. The most basic way to do so involves the following line of code:
 
 [source,java]
 ----
-GraphTraversalSource g = traversal().withRemote('conf/remote-graph.properties');
+GraphTraversalSource g = traversal().with('conf/remote-graph.properties');
 ----
 
 The `remote-graph.properties` file simply provides connection information to the `GraphTraversalSource` which is used
@@ -686,7 +686,7 @@ TinkerPop driver. The driver is configured by the specified `gremlin.remote.driv
 bound to the `GraphTraversalSource` on the remote end with `gremlin.remote.driver.sourceName` which in this case is
 also "g".
 
-There are other ways to configure the traversal using `withRemote()` as it has other overloads. It can take an
+There are other ways to configure the traversal using `with()` as it has other overloads. It can take an
 Apache Commons `Configuration` object which would have keys similar to those shown in the properties file and it
 can also take a `RemoteConnection` instance directly. The latter is interesting in that it means it is possible to
 programmatically construct all aspects of the `RemoteConnection`. For TinkerPop usage, that might mean directly
@@ -696,26 +696,26 @@ the command shown above could be re-written using programmatic construction as f
 [source,java]
 ----
 Cluster cluster = Cluster.open();
-GraphTraversalSource g = traversal().withRemote(DriverRemoteConnection.using(cluster, "g"));
+GraphTraversalSource g = traversal().with(DriverRemoteConnection.using(cluster, "g"));
 ----
 
 Please consider the following example:
 
 [gremlin-groovy]
 ----
-g = traversal().withRemote('conf/remote-graph.properties')
+g = traversal().with('conf/remote-graph.properties')
 g.V().elementMap()
 g.close()
 ----
 
 [source,java]
 ----
-GraphTraversalSource g = traversal().withRemote("conf/remote-graph.properties");
+GraphTraversalSource g = traversal().with("conf/remote-graph.properties");
 List<Map> list = g.V().elementMap();
 g.close();
 ----
 
-Note the call to `close()` above. The call to `withRemote()` internally instantiates a connection via the driver that
+Note the call to `close()` above. The call to `with()` internally instantiates a connection via the driver that
 can only be released by "closing" the `GraphTraversalSource`. It is important to take that step to release network
 resources associated with `g`.
 
@@ -726,7 +726,7 @@ objects and then re-use them.
 ----
 cluster = Cluster.open('conf/remote-objects.yaml')
 client = cluster.connect()
-g = traversal().withRemote(DriverRemoteConnection.using(client, "g"))
+g = traversal().with(DriverRemoteConnection.using(client, "g"))
 g.V().elementMap()
 g.close()
 client.close()
@@ -743,7 +743,7 @@ on the `TraversalSource`. For instance to set request timeout to 500 millisecond
 
 [source,java]
 ----
-GraphTraversalSource g = traversal().withRemote(conf);
+GraphTraversalSource g = traversal().with(conf);
 List<Vertex> vertices = g.with(Tokens.ARGS_EVAL_TIMEOUT, 500L).V().out("knows").toList()
 ----
 
@@ -851,7 +851,7 @@ Cluster cluster = Cluster.build().
                           serializer(serializer).
                           create();
 Client client = cluster.connect();
-GraphTraversalSource g = traversal().withRemote(DriverRemoteConnection.using(client, "g"));
+GraphTraversalSource g = traversal().with(DriverRemoteConnection.using(client, "g"));
 ----
 
 The `IoRegistry` tells the serializer what classes from the graph provider to auto-register during serialization.
@@ -1094,7 +1094,7 @@ Using the DSL then just involves telling the `Graph` to use it:
 
 [source,java]
 ----
-SocialTraversalSource social = traversal(SocialTraversalSource.class).withEmbedded(graph);
+SocialTraversalSource social = traversal(SocialTraversalSource.class).with(graph);
 social.V().has("name","marko").knows("josh");
 ----
 
@@ -1150,7 +1150,7 @@ It is then possible to use the `persons()` method to start traversals:
 
 [source,java]
 ----
-SocialTraversalSource social = traversal(SocialTraversalSource.class).withEmbedded(graph);
+SocialTraversalSource social = traversal(SocialTraversalSource.class).with(graph);
 social.persons("marko").knows("josh");
 ----
 
@@ -1280,7 +1280,7 @@ the remote end.
 
 [source,javascript]
 ----
-const g = traversal().withRemote(new DriverRemoteConnection('ws://localhost:8182/gremlin'));
+const g = traversal().with(new DriverRemoteConnection('ws://localhost:8182/gremlin'));
 ----
 
 Gremlin-JavaScript supports plain text SASL authentication, you can set it on the connection options.
@@ -1288,7 +1288,7 @@ Gremlin-JavaScript supports plain text SASL authentication, you can set it on th
 [source,javascript]
 ----
 const authenticator = new gremlin.driver.auth.PlainTextSaslAuthenticator('myuser', 'mypassword');
-const g = traversal().withRemote(new DriverRemoteConnection('ws://localhost:8182/gremlin', { authenticator });
+const g = traversal().with(new DriverRemoteConnection('ws://localhost:8182/gremlin', { authenticator });
 ----
 
 Given that I/O operations in Node.js are asynchronous by default, <<terminal-steps,Terminal Steps>> return a `Promise`:
@@ -1405,7 +1405,7 @@ builds on that content by demonstrating the transactional syntax for Javascript.
 
 [source,javascript]
 ----
-const g = traversal().withRemote(new DriverRemoteConnection('ws://localhost:8182/gremlin'));
+const g = traversal().with(new DriverRemoteConnection('ws://localhost:8182/gremlin'));
 const tx = g.tx(); // create a Transaction
 
 // spawn a new GraphTraversalSource binding all traversals established from it to tx
@@ -1603,7 +1603,7 @@ To use the DSL, simply initialize the `g` as follows:
 
 [source,javascript]
 ----
-const g = traversal(SocialTraversalSource).withRemote(connection);
+const g = traversal(SocialTraversalSource).with(connection);
 g.person('marko').aged(29).values('name').toList().
   then(names => console.log(names));
 ----
@@ -2626,7 +2626,7 @@ from asynchronous code using a thread.
 [source,python]
 ----
 def print_vertices():
-    g = traversal().withRemote(DriverRemoteConnection("ws://localhost:8182/gremlin"))
+    g = traversal().with(DriverRemoteConnection("ws://localhost:8182/gremlin"))
     # Do your traversal.
 
 async def run_in_thread():

--- a/docs/src/reference/gremlin-variants.asciidoc
+++ b/docs/src/reference/gremlin-variants.asciidoc
@@ -2128,7 +2128,7 @@ the "g" provided to the `DriverRemoteConnection` corresponds to the name of a `G
 
 [source,python]
 ----
-g = traversal().with_remote(DriverRemoteConnection('ws://localhost:8182/gremlin','g'))
+g = traversal().with_(DriverRemoteConnection('ws://localhost:8182/gremlin','g'))
 ----
 
 If you need to send additional headers in the websockets connection, you can pass an optional `headers` parameter
@@ -2136,7 +2136,7 @@ to the `DriverRemoteConnection` constructor.
 
 [source,python]
 ----
-g = traversal().with_remote(DriverRemoteConnection(
+g = traversal().with_(DriverRemoteConnection(
     'ws://localhost:8182/gremlin', 'g', headers={'Header':'Value'}))
 ----
 
@@ -2145,11 +2145,11 @@ Gremlin-Python supports plain text and Kerberos SASL authentication, you can set
 [source,python]
 ----
 # Plain text authentication
-g = traversal().with_remote(DriverRemoteConnection(
+g = traversal().with_(DriverRemoteConnection(
     'ws://localhost:8182/gremlin', 'g', username='stephen', password='password'))
 
 # Kerberos authentication
-g = traversal().with_remote(DriverRemoteConnection(
+g = traversal().with_(DriverRemoteConnection(
     'ws://localhost:8182/gremlin', 'g', kerberized_service='gremlin@hostname.your.org'))
 ----
 
@@ -2291,7 +2291,7 @@ and the ability to call the api from an event loop:
 ----
 import ssl
 ...
-g = traversal().with_remote(
+g = traversal().with_(
   DriverRemoteConnection('ws://localhost:8182/gremlin','g',
                          transport_factory=lambda: AiohttpTransport(read_timeout=60,
                                                                     write_timeout=20,
@@ -2352,7 +2352,7 @@ builds on that content by demonstrating the transactional syntax for Python.
 
 [source,python]
 ----
-g = traversal().with_remote(DriverRemoteConnection('ws://localhost:8182/gremlin'))
+g = traversal().with_(DriverRemoteConnection('ws://localhost:8182/gremlin'))
 
 # Create a Transaction.
 tx = g.tx()
@@ -2556,7 +2556,7 @@ be used:
 
 [source,python]
 ----
-social = traversal(SocialTraversalSource).with_remote(DriverRemoteConnection('ws://localhost:8182/gremlin','g'))
+social = traversal(SocialTraversalSource).with_(DriverRemoteConnection('ws://localhost:8182/gremlin','g'))
 social.persons('marko').knows('josh')
 social.persons('marko').youngest_friends_age()
 social.persons().filter(__.created_at_least(2)).count()
@@ -2626,7 +2626,7 @@ from asynchronous code using a thread.
 [source,python]
 ----
 def print_vertices():
-    g = traversal().with(DriverRemoteConnection("ws://localhost:8182/gremlin"))
+    g = traversal().with_(DriverRemoteConnection("ws://localhost:8182/gremlin"))
     # Do your traversal.
 
 async def run_in_thread():

--- a/docs/src/reference/implementations-hadoop-start.asciidoc
+++ b/docs/src/reference/implementations-hadoop-start.asciidoc
@@ -148,7 +148,7 @@ which is the OLAP Gremlin machine.
 hdfs.copyFromLocal('data/tinkerpop-modern.kryo', 'tinkerpop-modern.kryo')
 hdfs.ls()
 graph = GraphFactory.open('conf/hadoop/hadoop-gryo.properties')
-g = traversal().withEmbedded(graph)
+g = traversal().with(graph)
 g.V().count()
 g.V().out().out().values('name')
 g.V().group().by{it.value('name')[1]}.by('name').next()

--- a/docs/src/reference/implementations-neo4j.asciidoc
+++ b/docs/src/reference/implementations-neo4j.asciidoc
@@ -89,7 +89,7 @@ The Gremlin-Console session below demonstrates Neo4j indices. For more informati
 [gremlin-groovy]
 ----
 graph = Neo4jGraph.open('/tmp/neo4j')
-g = traversal().withEmbedded(graph)
+g = traversal().with(graph)
 graph.cypher("CREATE INDEX ON :person(name)")
 graph.tx().commit()  <1>
 g.addV('person').property('name','marko')
@@ -106,7 +106,7 @@ labels), a linear scan of the vertex-label partition is still faster than a line
 [gremlin-groovy]
 ----
 graph = Neo4jGraph.open('/tmp/neo4j')
-g = traversal().withEmbedded(graph)
+g = traversal().with(graph)
 g.io('data/grateful-dead.xml').read().iterate()
 g.tx().commit()
 clock(1000) {g.V().hasLabel('artist').has('name','Garcia').iterate()}  <1>
@@ -137,7 +137,7 @@ It is possible to leverage Cypher from within Gremlin by using the `Neo4jGraph.c
 [gremlin-groovy]
 ----
 graph = Neo4jGraph.open('/tmp/neo4j')
-g = traversal().withEmbedded(graph)
+g = traversal().with(graph)
 g.io('data/tinkerpop-modern.kryo').read().iterate()
 graph.cypher('MATCH (a {name:"marko"}) RETURN a')
 graph.cypher('MATCH (a {name:"marko"}) RETURN a').select('a').out('knows').values('name')
@@ -168,7 +168,7 @@ An example use case is presented below.
 [gremlin-groovy]
 ----
 graph = Neo4jGraph.open('/tmp/neo4j')
-g = traversal().withEmbedded(graph)
+g = traversal().with(graph)
 vertex = (Neo4jVertex) g.addV('human::animal').next() <1>
 vertex.label() <2>
 vertex.labels() <3>
@@ -228,7 +228,7 @@ which can then be used as follows:
 ----
 gremlin> graph = GraphFactory.open('neo4j.properties')
 ==>neo4jgraph[community single [/tmp/neo4j]]
-gremlin> g = traversal().withEmbedded(graph)
+gremlin> g = traversal().with(graph)
 ==>graphtraversalsource[neo4jgraph[community single [/tmp/neo4j]], standard]
 ----
 

--- a/docs/src/reference/implementations-spark.asciidoc
+++ b/docs/src/reference/implementations-spark.asciidoc
@@ -44,7 +44,7 @@ Once the `lib/` directory is distributed, `SparkGraphComputer` can be used as fo
 [gremlin-groovy]
 ----
 graph = GraphFactory.open('conf/hadoop/hadoop-gryo.properties')
-g = traversal().withEmbedded(graph).withComputer(SparkGraphComputer)
+g = traversal().with(graph).withComputer(SparkGraphComputer)
 g.V().count()
 g.V().out().out().values('name')
 ----
@@ -54,7 +54,7 @@ For using lambdas in Gremlin-Groovy, simply provide `:remote connect` a `Travers
 [gremlin-groovy]
 ----
 graph = GraphFactory.open('conf/hadoop/hadoop-gryo.properties')
-g = traversal().withEmbedded(graph).withComputer(SparkGraphComputer)
+g = traversal().with(graph).withComputer(SparkGraphComputer)
 :remote connect tinkerpop.hadoop graph g
 :> g.V().group().by{it.value('name')[1]}.by('name')
 ----

--- a/docs/src/reference/implementations-tinkergraph.asciidoc
+++ b/docs/src/reference/implementations-tinkergraph.asciidoc
@@ -44,7 +44,7 @@ Constructing a simple graph using TinkerGraph in Java is presented below:
 [source,java]
 ----
 Graph graph = TinkerGraph.open();
-GraphTraversalSource g = traversal().withEmbedded(graph);
+GraphTraversalSource g = traversal().with(graph);
 Vertex marko = g.addV("person").property("name","marko").property("age",29).next();
 Vertex lop = g.addV("software").property("name","lop").property("lang","java").next();
 g.addE("created").from(marko).to(lop).property("weight",0.6d).iterate();
@@ -89,11 +89,11 @@ TinkerGraph over the Grateful Dead graph.
 [gremlin-groovy]
 ----
 graph = TinkerGraph.open()
-g = traversal().withEmbedded(graph)
+g = traversal().with(graph)
 g.io('data/grateful-dead.xml').read().iterate()
 clock(1000) {g.V().has('name','Garcia').iterate()} <1>
 graph = TinkerGraph.open()
-g = traversal().withEmbedded(graph)
+g = traversal().with(graph)
 graph.createIndex('name',Vertex.class)
 g.io('data/grateful-dead.xml').read().iterate()
 clock(1000){g.V().has('name','Garcia').iterate()} <2>
@@ -118,7 +118,7 @@ especially in the case of numbers.
 [gremlin-groovy]
 ----
 graph = TinkerGraph.open()
-g = traversal().withEmbedded(graph)
+g = traversal().with(graph)
 g.addV().property('vp2',0.65780294)
 g.addV().property('vp2',0.65780294f)
 g.addV().property('vp2',0.65780294d)
@@ -191,13 +191,13 @@ cardinality to `list` or else the data will import as `single`.  Consider the fo
 [gremlin-groovy]
 ----
 graph = TinkerGraph.open()
-g = traversal().withEmbedded(graph)
+g = traversal().with(graph)
 g.io("data/tinkerpop-crew.kryo").read().iterate()
 g.V().properties()
 conf = new BaseConfiguration()
 conf.setProperty("gremlin.tinkergraph.defaultVertexPropertyCardinality","list")
 graph = TinkerGraph.open(conf)
-g = traversal().withEmbedded(graph)
+g = traversal().with(graph)
 g.io("data/tinkerpop-crew.kryo").read().iterate()
 g.V().properties()
 ----
@@ -260,7 +260,7 @@ public class GraphService {
 // suitable test graph replacement for our actual production graph.
 public class GraphServiceTest {
     private static final TinkerTransactionGraph graph = TinkerTransactionGraph().open();
-    private static final GraphTraversalSource g = traversal.withEmbedded(graph);
+    private static final GraphTraversalSource g = traversal.with(graph);
     private static final GraphService service = new GraphService(g);
 
     @Test
@@ -280,7 +280,7 @@ public class GraphServiceTest {
 // with this approach you could also configure your production graph directly or use custom
 // build options to trigger different test configurations for a more dynamic approach
 public class GraphServiceTest {
-    private static final GraphTraversalSource g = traversal.withRemote(
+    private static final GraphTraversalSource g = traversal.with(
             new DriverRemoteConnection('ws://localhost:8182/gremlin'));
     private static final GraphService service = new GraphService(g);
 
@@ -318,7 +318,7 @@ Constructing a simple graph using `TinkerTransactionGraph` in Java is presented 
 [source,java]
 ----
 Graph graph = TinkerTransactionGraph.open();
-g = traversal().withEmbedded(graph)
+g = traversal().with(graph)
 GraphTraversalSource gtx = g.tx().begin();
 
 try {
@@ -340,7 +340,7 @@ To use the embedded TinkerTransactionGraph in Gremlin Console:
 [gremlin-groovy]
 ----
 graph = TinkerTransactionGraph.open() <1>
-g = traversal().withEmbedded(graph) <2>
+g = traversal().with(graph) <2>
 g.addV('test').property('name','one')
 g.tx().commit() <3>
 g.V().valueMap()

--- a/docs/src/reference/intro.asciidoc
+++ b/docs/src/reference/intro.asciidoc
@@ -222,7 +222,7 @@ $ bin/gremlin.sh
 -----oOOo-(3)-oOOo-----
 gremlin> graph = TinkerFactory.createModern() // <1>
 ==>tinkergraph[vertices:6 edges:6]
-gremlin> g = traversal().withEmbedded(graph)        // <2>
+gremlin> g = traversal().with(graph)        // <2>
 ==>graphtraversalsource[tinkergraph[vertices:6 edges:6], standard]
 gremlin> g.V().has('name','marko').out('knows').values('name') // <3>
 ==>vadas
@@ -330,7 +330,7 @@ named "g":
 
 [source,java]
 ----
-GraphTraversalSource g = traversal().withEmbedded(graph);
+GraphTraversalSource g = traversal().with(graph);
 List<Vertex> vertices = g.V().toList()
 ----
 
@@ -385,7 +385,7 @@ import org.apache.tinkerpop.gremlin.driver.remote.DriverRemoteConnection;
 // gremlin-core module
 import static org.apache.tinkerpop.gremlin.process.traversal.AnonymousTraversalSource.traversal;
 
-GraphTraversalSource g = traversal().withRemote(
+GraphTraversalSource g = traversal().with(
                 DriverRemoteConnection.using("localhost", 8182));
 ----
 [source,groovy]
@@ -396,7 +396,7 @@ import org.apache.tinkerpop.gremlin.driver.remote.DriverRemoteConnection;
 // gremlin-core module
 import static org.apache.tinkerpop.gremlin.process.traversal.AnonymousTraversalSource.traversal;
 
-def g = traversal().withRemote(
+def g = traversal().with(
                 DriverRemoteConnection.using('localhost', 8182))
 ----
 [source,csharp]
@@ -409,14 +409,14 @@ include::../../../gremlin-dotnet/test/Gremlin.Net.IntegrationTest/Docs/Reference
 ----
 const traversal = gremlin.process.AnonymousTraversalSource.traversal;
 
-const g = traversal().withRemote(
+const g = traversal().with(
                 new DriverRemoteConnection('ws://localhost:8182/gremlin'));
 ----
 [source,python]
 ----
 from gremlin_python.process.anonymous_traversal_source import traversal
 
-g = traversal().withRemote(
+g = traversal().with(
           DriverRemoteConnection('ws://localhost:8182/gremlin'))
 ----
 [source,go]
@@ -426,7 +426,7 @@ import (
 )
 
 remote, err := gremlingo.NewDriverRemoteConnection("ws://localhost:8182/gremlin")
-g := gremlingo.Traversal_().WithRemote(remote)
+g := gremlingo.Traversal_().With(remote)
 ----
 
 As shown in the embedded approach in the previous section, once "g" is defined, writing Gremlin is structurally and

--- a/docs/src/reference/the-graph.asciidoc
+++ b/docs/src/reference/the-graph.asciidoc
@@ -33,7 +33,7 @@ spawn `GraphTraversalSource` instances so as to write Gremlin:
 [gremlin-groovy]
 ----
 graph = TinkerGraph.open()
-g = traversal().withEmbedded(graph)
+g = traversal().with(graph)
 g.addV('person')
 ----
 
@@ -117,7 +117,7 @@ A running example using vertex properties is provided below to demonstrate and e
 [gremlin-groovy]
 ----
 graph = TinkerGraph.open()
-g = traversal().withEmbedded(graph)
+g = traversal().with(graph)
 v = g.addV().property('name','marko').property('name','marko a. rodriguez').next()
 g.V(v).properties('name').count() <1>
 v.property(list, 'name', 'm. a. rodriguez') <2>

--- a/docs/src/reference/the-graphcomputer.asciidoc
+++ b/docs/src/reference/the-graphcomputer.asciidoc
@@ -80,7 +80,7 @@ memory manipulations).
 ----
 result = graph.compute().program(PageRankVertexProgram.build().create()).submit().get()
 result.memory().runtime
-g = traversal().withEmbedded(result.graph())
+g = traversal().with(result.graph())
 g.V().elementMap()
 ----
 
@@ -137,7 +137,7 @@ that the property is "hidden" unless it is directly accessed via name.
 graph = TinkerFactory.createModern()
 result = graph.compute().program(PeerPressureVertexProgram.build().create()).mapReduce(ClusterPopulationMapReduce.build().create()).submit().get()
 result.memory().get('clusterPopulation')
-g = traversal().withEmbedded(result.graph())
+g = traversal().with(result.graph())
 g.V().values(PeerPressureVertexProgram.CLUSTER).groupCount().next()
 g.V().elementMap()
 ----
@@ -367,7 +367,7 @@ The above `PageRankVertexProgram` is used as follows.
 ----
 result = graph.compute().program(PageRankVertexProgram.build().create()).submit().get()
 result.memory().runtime
-g = traversal().withEmbedded(result.graph())
+g = traversal().with(result.graph())
 g.V().elementMap()
 ----
 
@@ -375,7 +375,7 @@ Note that `GraphTraversal` provides a <<pagerank-step,`pageRank()`>>-step.
 
 [gremlin-groovy,modern]
 ----
-g = traversal().withEmbedded(graph).withComputer()
+g = traversal().with(graph).withComputer()
 g.V().pageRank().elementMap()
 g.V().pageRank().
         with(PageRank.propertyName, 'pageRank').
@@ -403,7 +403,7 @@ Note that `GraphTraversal` provides a <<peerpressure-step,`peerPressure()`>>-ste
 
 [gremlin-groovy,modern]
 ----
-g = traversal().withEmbedded(graph).withComputer()
+g = traversal().with(graph).withComputer()
 g.V().peerPressure().with(PeerPressure.propertyName, 'cluster').elementMap()
 g.V().peerPressure().
         with(PeerPressure.edges,outE('knows')).
@@ -503,9 +503,9 @@ link:https://dzone.com/articles/local-and-distributed-graph[Local and Distribute
 
 [gremlin-groovy,modern]
 ----
-g = traversal().withEmbedded(graph)
+g = traversal().with(graph)
 g.V().both().hasLabel('person').values('age').groupCount().next() // OLTP
-g = traversal().withEmbedded(graph).withComputer()
+g = traversal().with(graph).withComputer()
 g.V().both().hasLabel('person').values('age').groupCount().next() // OLAP
 ----
 

--- a/docs/src/reference/the-traversal.asciidoc
+++ b/docs/src/reference/the-traversal.asciidoc
@@ -63,9 +63,9 @@ demonstrated as follows:
 
 [source,java]
 ----
-GraphTraversalSource g = traversal().withEmbedded(graph);
+GraphTraversalSource g = traversal().with(graph);
 // or
-GraphTraversalSource g = traversal().withRemote(conn);
+GraphTraversalSource g = traversal().with(conn);
 
 Transaction tx = g.tx();
 
@@ -93,7 +93,7 @@ instances that are bound to the same transaction, therefore:
 
 [source,java]
 ----
-GraphTraversalSource g = traversal().withRemote(conn);
+GraphTraversalSource g = traversal().with(conn);
 Transaction tx1 = g.tx();
 Transaction tx2 = g.tx();
 
@@ -220,7 +220,7 @@ using this method.
 ----
 gremlin> graph = Neo4jGraph.open('/tmp/neo4j')
 ==>neo4jgraph[EmbeddedGraphDatabase [/tmp/neo4j]]
-gremlin> g = traversal().withEmbedded(graph)
+gremlin> g = traversal().with(graph)
 ==>graphtraversalsource[neo4jgraph[community single [/tmp/neo4j]], standard]
 gremlin> graph.features()
 ==>FEATURES
@@ -852,9 +852,9 @@ made more salient on a larger graph. Therefore, the example below leverages the 
 [gremlin-groovy]
 ----
 graph = TinkerGraph.open()
-g = traversal().withEmbedded(graph)
+g = traversal().with(graph)
 g.io('data/grateful-dead.xml').read().iterate()
-g = traversal().withEmbedded(graph).withoutStrategies(LazyBarrierStrategy) <1>
+g = traversal().with(graph).withoutStrategies(LazyBarrierStrategy) <1>
 clockWithResult(1){g.V().both().both().both().count().next()} <2>
 clockWithResult(1){g.V().repeat(both()).times(3).count().next()} <3>
 clockWithResult(1){g.V().both().barrier().both().barrier().both().barrier().count().next()} <4>
@@ -875,7 +875,7 @@ optimization scenario with the added benefit of reducing the risk of an out-of-m
 [gremlin-groovy]
 ----
 graph = TinkerGraph.open()
-g = traversal().withEmbedded(graph)  <1>
+g = traversal().with(graph)  <1>
 g.io('data/grateful-dead.xml').read().iterate()
 clockWithResult(1){g.V().both().both().both().count().next()}
 g.V().both().both().both().count().iterate().toString()  <2>
@@ -1243,7 +1243,7 @@ that supports `GraphComputer` (OLAP).
 
 [gremlin-groovy,modern]
 ----
-g = traversal().withEmbedded(graph).withComputer()
+g = traversal().with(graph).withComputer()
 g.V().
   connectedComponent().
     with(ConnectedComponent.propertyName, 'component').
@@ -2479,7 +2479,7 @@ songs which Jerry Garcia has both sung and written (using the Grateful Dead grap
 
 [gremlin-groovy]
 ----
-g = traversal().withEmbedded(graph)
+g = traversal().with(graph)
 g.io('data/grateful-dead.xml').read().iterate()
 g.V().match(
         __.as('a').has('name', 'Garcia'),
@@ -3377,7 +3377,7 @@ supports `GraphComputer` (OLAP).
 
 [gremlin-groovy,modern]
 ----
-g = traversal().withEmbedded(graph).withComputer()
+g = traversal().with(graph).withComputer()
 g.V().pageRank().with(PageRank.propertyName, 'friendRank').values('pageRank')
 g.V().hasLabel('person').
   pageRank().
@@ -3395,7 +3395,7 @@ The <<explain-step,`explain()`>>-step can be used to understand how the traversa
 
 [gremlin-groovy,modern]
 ----
-g = traversal().withEmbedded(graph).withComputer()
+g = traversal().with(graph).withComputer()
 g.V().hasLabel('person').
   pageRank().
     with(PageRank.edges, __.outE('knows')).
@@ -3516,7 +3516,7 @@ IMPORTANT: The `peerPressure()`-step is a `VertexComputing`-step and as such, ca
 
 [gremlin-groovy,modern]
 ----
-g = traversal().withEmbedded(graph).withComputer()
+g = traversal().with(graph).withComputer()
 g.V().peerPressure().with(PeerPressure.propertyName, 'cluster').values('cluster')
 g.V().hasLabel('person').
   peerPressure().
@@ -3708,7 +3708,7 @@ Finally, an example is provided using `PageRankVertexProgram` which doesn't use 
 
 [gremlin-groovy,modern]
 ----
-g = traversal().withEmbedded(graph).withComputer()
+g = traversal().with(graph).withComputer()
 g.V().hasLabel('person').
   program(PageRankVertexProgram.build().property('rank').create(graph)).
     order().by('rank', asc).
@@ -4195,7 +4195,7 @@ ranking.
 
 [gremlin-groovy]
 ----
-g = traversal().withEmbedded(graph)
+g = traversal().with(graph)
 g.io('data/grateful-dead.xml').read().iterate()
 g.V().hasLabel('song').out('followedBy').groupCount().by('name').
       order(local).by(values,desc).limit(local, 5)
@@ -4209,7 +4209,7 @@ Similarly, for extracting the values from a path or map.
 
 [gremlin-groovy]
 ----
-g = traversal().withEmbedded(graph)
+g = traversal().with(graph)
 g.io('data/grateful-dead.xml').read().iterate()
 g.V().hasLabel('song').out('sungBy').groupCount().by('name') <1>
 g.V().hasLabel('song').out('sungBy').groupCount().by('name').select(values) <2>
@@ -4484,7 +4484,7 @@ The following example demonstrates how to produce the "knows" subgraph:
 [gremlin-groovy,modern]
 ----
 subGraph = g.E().hasLabel('knows').subgraph('subGraph').cap('subGraph').next() <1>
-sg = traversal().withEmbedded(subGraph)
+sg = traversal().with(subGraph)
 sg.E() <2>
 ----
 
@@ -4496,7 +4496,7 @@ A more common subgraphing use case is to get all of the graph structure surround
 [gremlin-groovy,modern]
 ----
 subGraph = g.V(3).repeat(__.inE().subgraph('subGraph').outV()).times(3).cap('subGraph').next()  <1>
-sg = traversal().withEmbedded(subGraph)
+sg = traversal().with(subGraph)
 sg.E()
 ----
 
@@ -4517,8 +4517,8 @@ There can be multiple `subgraph()` calls within the same traversal. Each operati
 ----
 t = g.V().outE('knows').subgraph('knowsG').inV().outE('created').subgraph('createdG').
           inV().inE('created').subgraph('createdG').iterate()
-traversal().withEmbedded(t.sideEffects.get('knowsG')).E()
-traversal().withEmbedded(t.sideEffects.get('createdG')).E()
+traversal().with(t.sideEffects.get('knowsG')).E()
+traversal().with(t.sideEffects.get('createdG')).E()
 ----
 
 TinkerGraph is the ideal (and default) `Graph` into which a subgraph is extracted as it's fast, in-memory, and supports
@@ -5596,7 +5596,7 @@ allow specification of custom identifiers when creating elements:
 
 [gremlin-groovy]
 ----
-g = traversal().withEmbedded(TinkerGraph.open())
+g = traversal().with(TinkerGraph.open())
 v = g.addV().property(id,'42a').next()
 g.V('42a')
 ----
@@ -5609,7 +5609,7 @@ under the hood.
 ----
 graph = Neo4jGraph.open('/tmp/neo4j')
 strategy = ElementIdStrategy.build().create()
-g = traversal().withEmbedded(graph).withStrategies(strategy)
+g = traversal().with(graph).withStrategies(strategy)
 g.addV().property(id, '42a').id()
 ----
 
@@ -5644,7 +5644,7 @@ import org.apache.tinkerpop.gremlin.process.traversal.step.util.event.*
 graph = TinkerFactory.createModern()
 l = new ConsoleMutationListener(graph)
 strategy = EventStrategy.build().addListener(l).create()
-g = traversal().withEmbedded(graph).withStrategies(strategy)
+g = traversal().with(graph).withStrategies(strategy)
 g.addV().property('name','stephen')
 g.V().has('name','stephen').
   property(list, 'location', 'centreville', 'startTime', 1990, 'endTime', 2000).
@@ -5700,9 +5700,9 @@ The best way to understand `PartitionStrategy` is via example.
 graph = TinkerFactory.createModern()
 strategyA = new PartitionStrategy(partitionKey: "_partition", writePartition: "a", readPartitions: ["a"])
 strategyB = new PartitionStrategy(partitionKey: "_partition", writePartition: "b", readPartitions: ["b"])
-gA = traversal().withEmbedded(graph).withStrategies(strategyA)
+gA = traversal().with(graph).withStrategies(strategyA)
 gA.addV() // this vertex has a property of {_partition:"a"}
-gB = traversal().withEmbedded(graph).withStrategies(strategyB)
+gB = traversal().with(graph).withStrategies(strategyB)
 gB.addV() // this vertex has a property of {_partition:"b"}
 gA.V()
 gB.V()
@@ -5861,7 +5861,7 @@ these steps that make use of randomness to return results.
 [gremlin-groovy]
 ----
 graph = TinkerFactory.createTheCrew()
-g = traversal().withEmbedded(graph)
+g = traversal().with(graph)
 g.V().as('a').values('location').as('b').  <1>
   select('a','b').by('name').by()
 g = g.withStrategies(new SubgraphStrategy(vertexProperties: hasNot('endTime'))) <2>
@@ -5904,7 +5904,7 @@ non-location property.
 [gremlin-groovy]
 ----
 graph = TinkerFactory.createTheCrew()
-g = traversal().withEmbedded(graph).withStrategies(SubgraphStrategy.build().
+g = traversal().with(graph).withStrategies(SubgraphStrategy.build().
   vertices(or(hasNot('location'),properties('location').count().is(gt(3)))).
   edges(hasLabel('develops')).
   vertexProperties(or(hasLabel(neq('location')),hasNot('endTime'))).create())

--- a/docs/src/tutorials/getting-started/index.asciidoc
+++ b/docs/src/tutorials/getting-started/index.asciidoc
@@ -120,7 +120,7 @@ It can be instantiated in the console this way:
 [gremlin-groovy]
 ----
 graph = TinkerFactory.createModern()
-g = traversal().withEmbedded(graph)
+g = traversal().with(graph)
 ----
 
 The first command creates a `Graph` instance named `graph`, which thus provides a reference to the data you want
@@ -221,7 +221,7 @@ as an example. First, you need to create this graph:
 [gremlin-groovy]
 ----
 graph = TinkerGraph.open()
-g = traversal().withEmbedded(graph)
+g = traversal().with(graph)
 v1 = g.addV("person").property(id, 1).property("name", "marko").property("age", 29).next()
 v2 = g.addV("software").property(id, 3).property("name", "lop").property("lang", "java").next()
 g.addE("created").from(v1).to(v2).property(id, 9).property("weight", 0.4)
@@ -237,7 +237,7 @@ that static importing you would instead have to write:
 [gremlin-groovy]
 ----
 graph = TinkerGraph.open()
-g = traversal().withEmbedded(graph)
+g = traversal().with(graph)
 v1 = g.addV("person").property(T.id, 1).property("name", "marko").property("age", 29).next()
 v2 = g.addV("software").property(T.id, 3).property("name", "lop").property("lang", "java").next()
 g.addE("created").from(v1).to(v2).property(T.id, 9).property("weight", 0.4)
@@ -284,7 +284,7 @@ g.V().has('name','marko')
 ----
 
 NOTE: The variable `g` is the `TraversalSource`, which was introduced in the "The First Five Minutes". The
-`TraversalSource` is created with `traversal().withEmbedded(graph)` and is the object used to spawn new traversals.
+`TraversalSource` is created with `traversal().with(graph)` and is the object used to spawn new traversals.
 
 This bit of Gremlin can be improved and made more
 link:https://tinkerpop.apache.org/docs/x.y.z/recipes/#unspecified-label-in-global-vertex-lookup[idiomatically pleasing]
@@ -364,7 +364,7 @@ the "First Five Minutes" section. Recall that you can create this `Graph` and es
 [gremlin-groovy]
 ----
 graph = TinkerFactory.createModern()
-g = traversal().withEmbedded(graph)
+g = traversal().with(graph)
 ----
 
 Earlier we'd used the `has()`-step to tell Gremlin how to find the "marko" vertex. Let's look at some other ways to
@@ -536,7 +536,7 @@ TinkerGraph:
 graph = TinkerGraph.open()
 graph.createIndex('userId', Vertex.class) <1>
 
-g = traversal().withEmbedded(graph)
+g = traversal().with(graph)
 
 getOrCreate = { id ->
   g.V().has('user','userId', id).

--- a/docs/src/tutorials/the-gremlin-console/index.asciidoc
+++ b/docs/src/tutorials/the-gremlin-console/index.asciidoc
@@ -78,7 +78,7 @@ create an empty TinkerGraph as follows:
 [gremlin-groovy]
 ----
 graph = TinkerGraph.open()                 <1>
-g = traversal().withEmbedded(graph)        <2>
+g = traversal().with(graph)        <2>
 ----
 
 <1> Creates the `Graph` instance that is the API to the
@@ -115,7 +115,7 @@ link:https://tinkerpop.apache.org/docs/x.y.z/reference/#vertex-properties[vertex
 [gremlin-groovy]
 ----
 graph = TinkerFactory.createModern()
-g = traversal().withEmbedded(graph)
+g = traversal().with(graph)
 ----
 
 image:grateful-gremlin.png[float=right,width=110] As you might have noticed from the diagrams of these graphs or from
@@ -128,7 +128,7 @@ However, if you find that a larger graph might be helpful, there is another opti
 [gremlin-groovy]
 ----
 graph = TinkerFactory.createGratefulDead()
-g = traversal().withEmbedded(graph)
+g = traversal().with(graph)
 ----
 
 The Grateful Dead graph ships with the Gremlin Console and the data can be found in several formats (along with the
@@ -409,7 +409,7 @@ the data of the "person" vertices in the graph:
 [gremlin-groovy]
 ----
 graph = TinkerFactory.createTheCrew()
-g = traversal().withEmbedded(graph)
+g = traversal().with(graph)
 
 g.V().hasLabel('person').valueMap()
 ----

--- a/gremlin-archetype/gremlin-archetype-dsl/src/main/resources/archetype-resources/src/test/java/SocialDslTest.java
+++ b/gremlin-archetype/gremlin-archetype-dsl/src/main/resources/archetype-resources/src/test/java/SocialDslTest.java
@@ -32,7 +32,7 @@ import static org.junit.Assert.assertTrue;
 public class SocialDslTest {
 
     private Graph graph = TinkerFactory.createModern();
-    private SocialTraversalSource social = traversal(SocialTraversalSource.class).withGraph(graph);
+    private SocialTraversalSource social = traversal(SocialTraversalSource.class).with(graph);
 
     @Test
     public void shouldValidateThatMarkoKnowsJosh() {

--- a/gremlin-archetype/gremlin-archetype-server/src/main/resources/archetype-resources/src/main/java/Service.java
+++ b/gremlin-archetype/gremlin-archetype-server/src/main/resources/archetype-resources/src/main/java/Service.java
@@ -21,7 +21,6 @@ package ${package};
 import org.apache.tinkerpop.gremlin.driver.Cluster;
 import org.apache.tinkerpop.gremlin.driver.remote.DriverRemoteConnection;
 import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversalSource;
-import org.apache.tinkerpop.gremlin.structure.util.empty.EmptyGraph;
 
 import java.util.List;
 
@@ -40,7 +39,7 @@ public class Service implements AutoCloseable {
      * Construct a remote GraphTraversalSource using the above created Cluster instance that will connect to Gremlin
      * Server.
      */
-    private final GraphTraversalSource g = traversal().withRemote(DriverRemoteConnection.using(cluster));
+    private final GraphTraversalSource g = traversal().with(DriverRemoteConnection.using(cluster));
 
     /**
      * Create Service as a singleton given the simplicity of App.

--- a/gremlin-archetype/gremlin-archetype-tinkergraph/src/main/resources/archetype-resources/src/main/java/App.java
+++ b/gremlin-archetype/gremlin-archetype-tinkergraph/src/main/resources/archetype-resources/src/main/java/App.java
@@ -18,8 +18,6 @@
  */
 package ${package};
 
-import static org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.__.*;
-
 import java.util.List;
 import java.util.ArrayList;
 
@@ -28,6 +26,9 @@ import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversalSo
 import org.apache.tinkerpop.gremlin.structure.Graph;
 import org.apache.tinkerpop.gremlin.structure.T;
 import org.apache.tinkerpop.gremlin.structure.Vertex;
+
+import static org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.__.*;
+import static org.apache.tinkerpop.gremlin.process.traversal.AnonymousTraversalSource.traversal;
 
 public class App {
 
@@ -40,7 +41,7 @@ public class App {
         // Create a GraphTraversalSource instance that is used to query the data in the Graph instance. This variable
         // is typically denoted as "g".  In TinkerPop documentation you can always count on references to "g" as
         // being a object of this type.
-        GraphTraversalSource g = graph.traversal();
+        GraphTraversalSource g = traversal().with(graph);
 
         Vertex fromNode = findByName(g, "marko");
         Vertex toNode = findByName(g, "peter");

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/AnonymousTraversalSource.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/AnonymousTraversalSource.java
@@ -23,6 +23,7 @@ import org.apache.commons.configuration2.builder.fluent.Configurations;
 import org.apache.tinkerpop.gremlin.process.remote.RemoteConnection;
 import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversalSource;
 import org.apache.tinkerpop.gremlin.structure.Graph;
+import org.apache.tinkerpop.gremlin.structure.util.GraphFactory;
 
 /**
  * Provides a unified way to construct a {@link TraversalSource} from the perspective of the traversal. In this syntax
@@ -60,10 +61,11 @@ public class AnonymousTraversalSource<T extends TraversalSource> {
      * reference so that traversals spawned from it will execute over that reference.
      *
      * @param configFile a path to a file that would normally be provided to configure a {@link RemoteConnection}
+     * @deprecated As of release 4.0.0, replaced by {@link #with(String)}
      */
+    @Deprecated
     public T withRemote(final String configFile) throws Exception {
-        final Configurations configs = new Configurations();
-        return withRemote(configs.properties((configFile)));
+        return with(configFile);
     }
 
     /**
@@ -71,16 +73,52 @@ public class AnonymousTraversalSource<T extends TraversalSource> {
      * reference so that traversals spawned from it will execute over that reference.
      *
      * @param conf a {@code Configuration} object that would normally be provided to configure a {@link RemoteConnection}
+     * @deprecated As of release 4.0.0, replaced by {@link #with(Configuration)}
      */
+    @Deprecated
     public T withRemote(final Configuration conf) {
-        return withRemote(RemoteConnection.from(conf));
+        return with(RemoteConnection.from(conf));
+    }
+
+    /**
+     * Creates a {@link TraversalSource} binding a {@link RemoteConnection} to a remote {@link Graph} instances as its
+     * reference so that traversals spawned from it will execute over that reference.
+     *
+     * @deprecated As of release 4.0.0, replaced by {@link #with(RemoteConnection)}
+     */
+    @Deprecated
+    public T withRemote(final RemoteConnection remoteConnection) {
+        return with(remoteConnection);
+    }
+
+    /**
+     * Creates the specified {@link TraversalSource} binding an embedded {@link Graph} as its reference such that
+     * traversals spawned from it will execute over that reference.
+     *
+     * @deprecated As of release 4.0.0, replaced by {@link #with(Graph)}
+     */
+    @Deprecated
+    public T withEmbedded(final Graph graph) {
+        return with(graph);
+    }
+
+    /**
+     * Creates the specified {@link TraversalSource} binding an embedded {@link Graph} as its reference such that
+     * traversals spawned from it will execute over that reference.
+     */
+    public T with(final Graph graph) {
+        try {
+            return traversalSourceClass.getConstructor(Graph.class).newInstance(graph);
+        } catch (final Exception e) {
+            throw new IllegalStateException(e.getMessage(), e);
+        }
     }
 
     /**
      * Creates a {@link TraversalSource} binding a {@link RemoteConnection} to a remote {@link Graph} instances as its
      * reference so that traversals spawned from it will execute over that reference.
      */
-    public T withRemote(final RemoteConnection remoteConnection) {
+    public T with(final RemoteConnection remoteConnection) {
         try {
             return traversalSourceClass.getConstructor(RemoteConnection.class).newInstance(remoteConnection);
         } catch (final Exception e) {
@@ -89,25 +127,27 @@ public class AnonymousTraversalSource<T extends TraversalSource> {
     }
 
     /**
-     * Creates the specified {@link TraversalSource} binding an embedded {@link Graph} as its reference such that
-     * traversals spawned from it will execute over that reference.
+     * Creates a {@link TraversalSource} from a configuration file which may either be for a {@link Graph} instance or
+     * for a {@link RemoteConnection}.
      *
-     * @deprecated As of release 3.4.9, replaced by {@link #withEmbedded(Graph)}
+     * @param configFile a path to a configuration file
      */
-    @Deprecated
-    public T withGraph(final Graph graph) {
-        return withEmbedded(graph);
+    public T with(final String configFile) throws Exception {
+        final Configurations configs = new Configurations();
+        return with(configs.properties((configFile)));
     }
 
     /**
-     * Creates the specified {@link TraversalSource} binding an embedded {@link Graph} as its reference such that
-     * traversals spawned from it will execute over that reference.
+     * Creates a {@link TraversalSource} from a configuration object which may either be for a {@link Graph} instance or
+     * for a {@link RemoteConnection}.
+     *
+     * @param conf a {@code Configuration} object that would normally be provided to configure a {@link RemoteConnection}
      */
-    public T withEmbedded(final Graph graph) {
-        try {
-            return traversalSourceClass.getConstructor(Graph.class).newInstance(graph);
-        } catch (final Exception e) {
-            throw new IllegalStateException(e.getMessage(), e);
-        }
+    public T with(final Configuration conf) {
+        // detect the type of configuration then read the configuration from the right constructor
+        if (conf.containsKey(Graph.GRAPH))
+            return with(GraphFactory.open(conf));
+        else
+            return with(RemoteConnection.from(conf));
     }
 }

--- a/gremlin-core/src/test/java/org/apache/tinkerpop/gremlin/process/traversal/TraversalTest.java
+++ b/gremlin-core/src/test/java/org/apache/tinkerpop/gremlin/process/traversal/TraversalTest.java
@@ -135,7 +135,7 @@ public class TraversalTest {
 
     @Test
     public void shouldOnlyAllowAnonymousChildren() {
-        final GraphTraversalSource g = traversal().withGraph(EmptyGraph.instance());
+        final GraphTraversalSource g = traversal().with(EmptyGraph.instance());
         g.V(1).addE("self").to(__.V(1));
         try {
             g.V(1).addE("self").to(g.V(1));

--- a/gremlin-dotnet/src/Gremlin.Net.Template/Program.cs
+++ b/gremlin-dotnet/src/Gremlin.Net.Template/Program.cs
@@ -42,7 +42,7 @@ namespace Gremlin.Net.Template
             });
             using var connection = new DriverRemoteConnection(new GremlinClient(
                 new GremlinServer(GremlinServerHostname, GremlinServerPort), loggerFactory: loggerFactory));
-            var g = Traversal().WithRemote(connection);
+            var g = Traversal().With(connection);
             var service = new Service(g);
             var creators = service.FindCreatorsOfSoftware("lop");
             foreach (var c in creators)

--- a/gremlin-dotnet/src/Gremlin.Net/Process/Traversal/AnonymousTraversalSource.cs
+++ b/gremlin-dotnet/src/Gremlin.Net/Process/Traversal/AnonymousTraversalSource.cs
@@ -21,7 +21,10 @@
 
 #endregion
 
+using System;
+using System.Collections.Generic;
 using Gremlin.Net.Structure;
+using Gremlin.Net.Process.Remote;
 
 namespace Gremlin.Net.Process.Traversal
 {
@@ -39,10 +42,23 @@ namespace Gremlin.Net.Process.Traversal
         ///     Generates a reusable <see cref="GraphTraversalSource" /> instance.
         /// </summary>
         /// <returns>A graph traversal source.</returns>
-        public static GraphTraversalSource Traversal()
+        public static AnonymousTraversalSource Traversal()
         {
-            return new GraphTraversalSource();
+            return new AnonymousTraversalSource();
         }
+
+        /// <summary>
+        ///     Configures the <see cref="GraphTraversalSource" /> as a "remote" to issue the
+        ///     <see cref="GraphTraversal{SType, EType}" /> for execution elsewhere.
+        /// </summary>
+        /// <param name="remoteConnection">
+        ///     The <see cref="IRemoteConnection" /> instance to use to submit the
+        ///     <see cref="GraphTraversal{SType, EType}" />.
+        /// </param>
+        /// <returns>A <see cref="GraphTraversalSource" /> configured to use the provided <see cref="IRemoteConnection" />.</returns>
+        public GraphTraversalSource With(IRemoteConnection remoteConnection) =>
+            new GraphTraversalSource(new List<ITraversalStrategy>(),
+                new Bytecode(), remoteConnection);
     }
 
 }

--- a/gremlin-dotnet/src/Gremlin.Net/Process/Traversal/GraphTraversalSource.cs
+++ b/gremlin-dotnet/src/Gremlin.Net/Process/Traversal/GraphTraversalSource.cs
@@ -262,6 +262,7 @@ namespace Gremlin.Net.Process.Traversal
         ///     <see cref="GraphTraversal{SType, EType}" />.
         /// </param>
         /// <returns>A <see cref="GraphTraversalSource" /> configured to use the provided <see cref="IRemoteConnection" />.</returns>
+        [Obsolete("Prefer use of AnonymousTraversalSource.with().", false)]
         public GraphTraversalSource WithRemote(IRemoteConnection remoteConnection) =>
             new GraphTraversalSource(new List<ITraversalStrategy>(TraversalStrategies),
                 new Bytecode(Bytecode), remoteConnection);

--- a/gremlin-dotnet/test/Gremlin.Net.Benchmarks/CompressionBenchmarks.cs
+++ b/gremlin-dotnet/test/Gremlin.Net.Benchmarks/CompressionBenchmarks.cs
@@ -61,7 +61,7 @@ public class CompressionBenchmarks
 
     private static async Task PerformBenchmarkWithClient(GremlinClient client)
     {
-        var g = Traversal().WithRemote(new DriverRemoteConnection(client));
+        var g = Traversal().With(new DriverRemoteConnection(client));
         for (var i = 0; i < 5; i++)
         {
             await g.V().Repeat(Both()).Times(10).Emit().Fold().Promise(t => t.ToList());

--- a/gremlin-dotnet/test/Gremlin.Net.Benchmarks/MessageSerializerBenchmarks.cs
+++ b/gremlin-dotnet/test/Gremlin.Net.Benchmarks/MessageSerializerBenchmarks.cs
@@ -41,7 +41,7 @@ namespace Gremlin.Net.Benchmarks
     {
         private static readonly Bytecode EmptyBytecode = new Bytecode();
 
-        private static readonly Bytecode SomeBytecode = Traversal().WithComputer().V().
+        private static readonly Bytecode SomeBytecode = Traversal().With(null).WithComputer().V().
             Has("Name", "marko").
             Where(
                 Out("knows").

--- a/gremlin-dotnet/test/Gremlin.Net.IntegrationTest/Docs/Reference/GremlinApplicationsTests.cs
+++ b/gremlin-dotnet/test/Gremlin.Net.IntegrationTest/Docs/Reference/GremlinApplicationsTests.cs
@@ -53,7 +53,7 @@ using (var gremlinClient = new GremlinClient(gremlinServer))
 // bytecode
 using (var gremlinClient = new GremlinClient(new GremlinServer("localhost", 8182)))
 {
-    var g = Traversal().WithRemote(new DriverRemoteConnection(gremlinClient));
+    var g = Traversal().With(new DriverRemoteConnection(gremlinClient));
     var list = g.V().Has("person", "name", "marko").Out("knows").ToList();
 }
 // end::connectingViaDrivers[]

--- a/gremlin-dotnet/test/Gremlin.Net.IntegrationTest/Docs/Reference/GremlinVariantsDslTests.cs
+++ b/gremlin-dotnet/test/Gremlin.Net.IntegrationTest/Docs/Reference/GremlinVariantsDslTests.cs
@@ -43,7 +43,7 @@ namespace Gremlin.Net.IntegrationTest.Docs.Reference
         {
 // tag::dslExamples[]
 var connection = new DriverRemoteConnection(new GremlinClient(new GremlinServer("localhost", 8182)));
-var social = Traversal().WithRemote(connection);
+var social = Traversal().With(connection);
 
 social.Persons("marko").Knows("josh");
 social.Persons("marko").YoungestFriendsAge();
@@ -55,7 +55,7 @@ social.Persons().Filter(CreatedAtLeast(2)).Count();
         public void ShouldUseDsl() 
         {
             var connection = _connectionFactory.CreateRemoteConnection();
-            var social = AnonymousTraversalSource.Traversal().WithRemote(connection);
+            var social = AnonymousTraversalSource.Traversal().With(connection);
 
             Assert.NotNull(social.Persons("marko").Knows("josh").Next());
             Assert.Equal(27, social.Persons("marko").YoungestFriendsAge().Next());

--- a/gremlin-dotnet/test/Gremlin.Net.IntegrationTest/Docs/Reference/GremlinVariantsTests.cs
+++ b/gremlin-dotnet/test/Gremlin.Net.IntegrationTest/Docs/Reference/GremlinVariantsTests.cs
@@ -55,14 +55,14 @@ namespace Gremlin.Net.IntegrationTest.Docs.Reference
     public class GremlinVariantsTests
     {
         private readonly GraphTraversalSource g = Traversal()
-            .WithRemote(new RemoteConnectionFactory().CreateRemoteConnection());
+            .With(new RemoteConnectionFactory().CreateRemoteConnection());
         
         [Fact(Skip="No Server under localhost")]
         public void ConnectingTest()
         {
 // tag::connecting[]
 using var remoteConnection = new DriverRemoteConnection(new GremlinClient(new GremlinServer("localhost", 8182)), "g");
-var g = Traversal().WithRemote(remoteConnection);
+var g = Traversal().With(remoteConnection);
 // end::connecting[]
         }
         
@@ -169,7 +169,7 @@ var gremlinServer = new GremlinServer("localhost", 8182, true, username, passwor
         {
 // tag::transactions[]
 using var gremlinClient = new GremlinClient(new GremlinServer("localhost", 8182));
-var g = Traversal().WithRemote(new DriverRemoteConnection(gremlinClient));
+var g = Traversal().With(new DriverRemoteConnection(gremlinClient));
 var tx = g.Tx();    // create a transaction
 
 // spawn a new GraphTraversalSource binding all traversals established from it to tx

--- a/gremlin-dotnet/test/Gremlin.Net.IntegrationTest/Docs/Reference/IntroTests.cs
+++ b/gremlin-dotnet/test/Gremlin.Net.IntegrationTest/Docs/Reference/IntroTests.cs
@@ -34,13 +34,13 @@ namespace Gremlin.Net.IntegrationTest.Docs.Reference
     public class IntroTests
     {
         private readonly GraphTraversalSource g = Traversal()
-            .WithRemote(new RemoteConnectionFactory().CreateRemoteConnection());
+            .With(new RemoteConnectionFactory().CreateRemoteConnection());
 
         [Fact(Skip="No Server under localhost")]
         public void TraversalSourceCreationTest()
         {
 // tag::traversalSourceCreation[]
-var g = Traversal().WithRemote(new DriverRemoteConnection("localhost", 8182));
+var g = Traversal().With(new DriverRemoteConnection("localhost", 8182));
 // end::traversalSourceCreation[]
         }
         

--- a/gremlin-dotnet/test/Gremlin.Net.IntegrationTest/Docs/Upgrade/Release35Tests.cs
+++ b/gremlin-dotnet/test/Gremlin.Net.IntegrationTest/Docs/Upgrade/Release35Tests.cs
@@ -36,7 +36,7 @@ namespace Gremlin.Net.IntegrationTest.Docs.Upgrade
         {
 // tag::graphBinary[]
 var client = new GremlinClient(new GremlinServer("localhost", 8182), new GraphBinaryMessageSerializer());
-var g = Traversal().WithRemote(new DriverRemoteConnection(client));
+var g = Traversal().With(new DriverRemoteConnection(client));
 // end::graphBinary[]
         }
     }

--- a/gremlin-dotnet/test/Gremlin.Net.IntegrationTest/Driver/PropertyDeserializationTests.cs
+++ b/gremlin-dotnet/test/Gremlin.Net.IntegrationTest/Driver/PropertyDeserializationTests.cs
@@ -44,7 +44,7 @@ namespace Gremlin.Net.IntegrationTest.Driver
         public void ShouldDeserializeVertexPropertiesForBytecode(IMessageSerializer serializer)
         {
             var connection = _connectionFactory.CreateRemoteConnection("gmodern", 2, serializer);
-            var g = AnonymousTraversalSource.Traversal().WithRemote(connection);
+            var g = AnonymousTraversalSource.Traversal().With(connection);
 
             var vertex = g.V(1).Next();
 
@@ -56,7 +56,7 @@ namespace Gremlin.Net.IntegrationTest.Driver
         public void ShouldRespectMaterializePropertiesTokensForBytecode(IMessageSerializer serializer)
         {
             var connection = _connectionFactory.CreateRemoteConnection("gmodern", 2, serializer);
-            var g = AnonymousTraversalSource.Traversal().WithRemote(connection);
+            var g = AnonymousTraversalSource.Traversal().With(connection);
 
             var vertex = g.With(Tokens.ArgMaterializeProperties, "tokens").V(1).Next();
 
@@ -68,7 +68,7 @@ namespace Gremlin.Net.IntegrationTest.Driver
         public void ShouldRespectMaterializePropertiesAllForBytecode(IMessageSerializer serializer)
         {
             var connection = _connectionFactory.CreateRemoteConnection("gmodern", 2, serializer);
-            var g = AnonymousTraversalSource.Traversal().WithRemote(connection);
+            var g = AnonymousTraversalSource.Traversal().With(connection);
 
             var vertex = g.With(Tokens.ArgMaterializeProperties, "all").V(1).Next();
 
@@ -80,7 +80,7 @@ namespace Gremlin.Net.IntegrationTest.Driver
         public void ShouldHandleEmptyVertexPropertiesForBytecode(IMessageSerializer serializer)
         {
             var connection = _connectionFactory.CreateRemoteConnection("gimmutable", 2, serializer);
-            var g = AnonymousTraversalSource.Traversal().WithRemote(connection);
+            var g = AnonymousTraversalSource.Traversal().With(connection);
 
             var vertex = g.AddV("test").Next();
 
@@ -136,7 +136,7 @@ namespace Gremlin.Net.IntegrationTest.Driver
         public void ShouldDeserializeEdgePropertiesForBytecode(IMessageSerializer serializer)
         {
             var connection = _connectionFactory.CreateRemoteConnection("gmodern", 2, serializer);
-            var g = AnonymousTraversalSource.Traversal().WithRemote(connection);
+            var g = AnonymousTraversalSource.Traversal().With(connection);
 
             var edge = g.E(7).Next();
 
@@ -148,7 +148,7 @@ namespace Gremlin.Net.IntegrationTest.Driver
         public void ShouldHandleEmptyEdgePropertiesForBytecode(IMessageSerializer serializer)
         {
             var connection = _connectionFactory.CreateRemoteConnection("gimmutable", 2, serializer);
-            var g = AnonymousTraversalSource.Traversal().WithRemote(connection);
+            var g = AnonymousTraversalSource.Traversal().With(connection);
 
             var v1 = g.AddV("v1").Next();
             var v2 = g.AddV("v2").Next();
@@ -185,7 +185,7 @@ namespace Gremlin.Net.IntegrationTest.Driver
         public void ShouldHandleMultiplePropertiesWithSameNameForVertex(IMessageSerializer serializer)
         {
             var connection = _connectionFactory.CreateRemoteConnection("gimmutable", 2, serializer);
-            var g = AnonymousTraversalSource.Traversal().WithRemote(connection);
+            var g = AnonymousTraversalSource.Traversal().With(connection);
 
             var vertex = g.AddV()
                 .Property(Cardinality.List, "test", "value1")
@@ -209,7 +209,7 @@ namespace Gremlin.Net.IntegrationTest.Driver
         public void ShouldDeserializeVertexVertexPropertiesForBytecode(IMessageSerializer serializer)
         {
             var connection = _connectionFactory.CreateRemoteConnection("gcrew", 2, serializer);
-            var g = AnonymousTraversalSource.Traversal().WithRemote(connection);
+            var g = AnonymousTraversalSource.Traversal().With(connection);
 
             var vertex = g.V(7).Next();
 

--- a/gremlin-dotnet/test/Gremlin.Net.IntegrationTest/Gherkin/CommonSteps.cs
+++ b/gremlin-dotnet/test/Gremlin.Net.IntegrationTest/Gherkin/CommonSteps.cs
@@ -105,7 +105,7 @@ namespace Gremlin.Net.IntegrationTest.Gherkin
             }
             var data = ScenarioData.GetByGraphName(graphName);
             _graphName = graphName;
-            _g = Traversal().WithRemote(data.Connection);
+            _g = Traversal().With(data.Connection);
         }
 
         [Given("using the parameter (\\w+) defined as \"(.*)\"")]

--- a/gremlin-dotnet/test/Gremlin.Net.IntegrationTest/Gherkin/ScenarioData.cs
+++ b/gremlin-dotnet/test/Gremlin.Net.IntegrationTest/Gherkin/ScenarioData.cs
@@ -70,14 +70,14 @@ namespace Gremlin.Net.IntegrationTest.Gherkin
 
         public void CleanEmptyData()
         {
-            var g = Traversal().WithRemote(GetByGraphName("empty").Connection);
+            var g = Traversal().With(GetByGraphName("empty").Connection);
             g.V().Drop().Iterate();
         }
 
         public void ReloadEmptyData()
         {
             var graphData = _dataPerGraph["empty"];
-            var g = Traversal().WithRemote(graphData.Connection);
+            var g = Traversal().With(graphData.Connection);
             graphData.Vertices = GetVertices(g);
             graphData.Edges = GetEdges(g);
             graphData.VertexProperties = GetVertexProperties(g);
@@ -99,7 +99,7 @@ namespace Gremlin.Net.IntegrationTest.Gherkin
             return GraphNames.Select(name =>
             {
                 var connection = _connectionFactory.CreateRemoteConnection($"g{name}");
-                var g = Traversal().WithRemote(connection);
+                var g = Traversal().With(connection);
                 return new ScenarioDataPerGraph(name, connection, GetVertices(g), GetEdges(g), GetVertexProperties(g));
             }).ToDictionary(x => x.Name);
         }

--- a/gremlin-dotnet/test/Gremlin.Net.IntegrationTest/Process/Traversal/BytecodeGeneration/BytecodeGenerationTests.cs
+++ b/gremlin-dotnet/test/Gremlin.Net.IntegrationTest/Process/Traversal/BytecodeGeneration/BytecodeGenerationTests.cs
@@ -32,7 +32,7 @@ namespace Gremlin.Net.IntegrationTest.Process.Traversal.BytecodeGeneration
         [Fact]
         public void GraphTraversalStepsShouldUnrollParamsParameters()
         {
-            var g = AnonymousTraversalSource.Traversal();
+            var g = AnonymousTraversalSource.Traversal().With(null);
 
             var bytecode = g.V().HasLabel("firstLabel", "secondLabel", "thirdLabel").Bytecode;
 
@@ -44,7 +44,7 @@ namespace Gremlin.Net.IntegrationTest.Process.Traversal.BytecodeGeneration
         [Fact]
         public void g_V_OutXcreatedX()
         {
-            var g = AnonymousTraversalSource.Traversal();
+            var g = AnonymousTraversalSource.Traversal().With(null);
 
             var bytecode = g.V().Out("created").Bytecode;
 
@@ -59,7 +59,7 @@ namespace Gremlin.Net.IntegrationTest.Process.Traversal.BytecodeGeneration
         [Fact]
         public void g_WithSackX1X_E_GroupCount_ByXweightX()
         {
-            var g = AnonymousTraversalSource.Traversal();
+            var g = AnonymousTraversalSource.Traversal().With(null);
 
             var bytecode = g.WithSack(1).E().GroupCount<double>().By("weight").Bytecode;
 
@@ -79,7 +79,7 @@ namespace Gremlin.Net.IntegrationTest.Process.Traversal.BytecodeGeneration
         [Fact]
         public void g_InjectX1_2_3X()
         {
-            var g = AnonymousTraversalSource.Traversal();
+            var g = AnonymousTraversalSource.Traversal().With(null);
 
             var bytecode = g.Inject(1, 2, 3).Bytecode;
 

--- a/gremlin-dotnet/test/Gremlin.Net.IntegrationTest/Process/Traversal/BytecodeGeneration/StrategiesTests.cs
+++ b/gremlin-dotnet/test/Gremlin.Net.IntegrationTest/Process/Traversal/BytecodeGeneration/StrategiesTests.cs
@@ -36,7 +36,7 @@ namespace Gremlin.Net.IntegrationTest.Process.Traversal.BytecodeGeneration
         [Fact]
         public void TraversalWithoutStrategies_AfterWithStrategiesWasCalled_WithStrategiesNotAffected()
         {
-            var g = AnonymousTraversalSource.Traversal().WithStrategies(new ReadOnlyStrategy(), new IncidentToAdjacentStrategy());
+            var g = new GraphTraversalSource().WithStrategies(new ReadOnlyStrategy(), new IncidentToAdjacentStrategy());
 
             var bytecode = g.WithoutStrategies(typeof(ReadOnlyStrategy)).Bytecode;
 
@@ -54,7 +54,7 @@ namespace Gremlin.Net.IntegrationTest.Process.Traversal.BytecodeGeneration
         [Fact]
         public void ShouldIncludeMultipleStrategiesInBytecodeWhenGivenToWithoutStrategies()
         {
-            var g = AnonymousTraversalSource.Traversal();
+            var g = new GraphTraversalSource();
 
             var bytecode = g.WithoutStrategies(typeof(ReadOnlyStrategy), typeof(LazyBarrierStrategy)).Bytecode;
 
@@ -68,7 +68,7 @@ namespace Gremlin.Net.IntegrationTest.Process.Traversal.BytecodeGeneration
         [Fact]
         public void ShouldIncludeOneStrategyInBytecodeWhenGivenToWithoutStrategies()
         {
-            var g = AnonymousTraversalSource.Traversal();
+            var g = new GraphTraversalSource();
 
             var bytecode = g.WithoutStrategies(typeof(ReadOnlyStrategy)).Bytecode;
 
@@ -81,7 +81,7 @@ namespace Gremlin.Net.IntegrationTest.Process.Traversal.BytecodeGeneration
         [Fact]
         public void ShouldIncludeConfigurationInBytecodeWhenGivenToWithStrategies()
         {
-            var g = AnonymousTraversalSource.Traversal();
+            var g = new GraphTraversalSource();
 
             var bytecode = g.WithStrategies(new MatchAlgorithmStrategy("greedy")).Bytecode;
 
@@ -96,7 +96,7 @@ namespace Gremlin.Net.IntegrationTest.Process.Traversal.BytecodeGeneration
         [Fact]
         public void ShouldIncludeMultipleStrategiesInBytecodeWhenGivenToWithStrategies()
         {
-            var g = AnonymousTraversalSource.Traversal();
+            var g = new GraphTraversalSource();
 
             var bytecode = g.WithStrategies(new ReadOnlyStrategy(), new IncidentToAdjacentStrategy()).Bytecode;
 
@@ -110,7 +110,7 @@ namespace Gremlin.Net.IntegrationTest.Process.Traversal.BytecodeGeneration
         [Fact]
         public void ShouldIncludeOneStrategyInBytecodeWhenGivenToWithStrategies()
         {
-            var g = AnonymousTraversalSource.Traversal();
+            var g = new GraphTraversalSource();
 
             var bytecode = g.WithStrategies(new ReadOnlyStrategy()).Bytecode;
 
@@ -127,7 +127,7 @@ namespace Gremlin.Net.IntegrationTest.Process.Traversal.BytecodeGeneration
         [Fact]
         public void TraversalWithStrategies_Strategies_ApplyToReusedGraphTraversalSource()
         {
-            var g = AnonymousTraversalSource.Traversal().WithStrategies(new ReadOnlyStrategy(), new IncidentToAdjacentStrategy());
+            var g = new GraphTraversalSource().WithStrategies(new ReadOnlyStrategy(), new IncidentToAdjacentStrategy());
 
             var bytecode = g.V().Bytecode;
 
@@ -143,7 +143,7 @@ namespace Gremlin.Net.IntegrationTest.Process.Traversal.BytecodeGeneration
         [Fact]
         public void TraversalWithStrategies_StrategyWithTraversalInConfig_IncludeTraversalInInConfigInBytecode()
         {
-            var g = AnonymousTraversalSource.Traversal();
+            var g = new GraphTraversalSource();
 
             var bytecode = g.WithStrategies(new SubgraphStrategy(__.Has("name", "marko"), checkAdjacentVertices: false)).Bytecode;
 

--- a/gremlin-dotnet/test/Gremlin.Net.IntegrationTest/Process/Traversal/DriverRemoteConnection/EnumTests.cs
+++ b/gremlin-dotnet/test/Gremlin.Net.IntegrationTest/Process/Traversal/DriverRemoteConnection/EnumTests.cs
@@ -35,7 +35,7 @@ namespace Gremlin.Net.IntegrationTest.Process.Traversal.DriverRemoteConnection
         public void ShouldUseOrderDecrInByStep()
         {
             var connection = _connectionFactory.CreateRemoteConnection();
-            var g = AnonymousTraversalSource.Traversal().WithRemote(connection);
+            var g = AnonymousTraversalSource.Traversal().With(connection);
 
             var orderedAges = g.V().Values<int>("age").Order().By(Order.Desc).ToList();
 
@@ -46,7 +46,7 @@ namespace Gremlin.Net.IntegrationTest.Process.Traversal.DriverRemoteConnection
         public void ShouldUseTLabelInHasStep()
         {
             var connection = _connectionFactory.CreateRemoteConnection();
-            var g = AnonymousTraversalSource.Traversal().WithRemote(connection);
+            var g = AnonymousTraversalSource.Traversal().With(connection);
 
             var personsCount = g.V().Has(T.Label, "person").Count().Next();
 

--- a/gremlin-dotnet/test/Gremlin.Net.IntegrationTest/Process/Traversal/DriverRemoteConnection/GraphTraversalSourceTests.cs
+++ b/gremlin-dotnet/test/Gremlin.Net.IntegrationTest/Process/Traversal/DriverRemoteConnection/GraphTraversalSourceTests.cs
@@ -35,7 +35,7 @@ namespace Gremlin.Net.IntegrationTest.Process.Traversal.DriverRemoteConnection
         public void ShouldUseSideEffectSpecifiedInWithSideEffect()
         {
             var connection = _connectionFactory.CreateRemoteConnection();
-            var g = AnonymousTraversalSource.Traversal().WithRemote(connection);
+            var g = AnonymousTraversalSource.Traversal().With(connection);
 
             var results = g.WithSideEffect("a", new List<string> {"josh", "peter"})
                 .V(1)
@@ -54,7 +54,7 @@ namespace Gremlin.Net.IntegrationTest.Process.Traversal.DriverRemoteConnection
         public void ShouldHandleLambdasInWithSack()
         {
             var connection = _connectionFactory.CreateRemoteConnection();
-            var g = AnonymousTraversalSource.Traversal().WithRemote(connection);
+            var g = AnonymousTraversalSource.Traversal().With(connection);
 
             Assert.Equal(24.0, g.WithSack(1.0, (IUnaryOperator) Lambda.Groovy("x -> x + 1")).V().Both().Sack<double>().Sum<double>().Next());                        
             Assert.Equal(24.0, g.WithSack((ISupplier) Lambda.Groovy("{1.0d}"), (IUnaryOperator) Lambda.Groovy("x -> x + 1")).V().Both().Sack<double>().Sum<double>().Next());

--- a/gremlin-dotnet/test/Gremlin.Net.IntegrationTest/Process/Traversal/DriverRemoteConnection/GraphTraversalTests.cs
+++ b/gremlin-dotnet/test/Gremlin.Net.IntegrationTest/Process/Traversal/DriverRemoteConnection/GraphTraversalTests.cs
@@ -276,7 +276,7 @@ namespace Gremlin.Net.IntegrationTest.Process.Traversal.DriverRemoteConnection
         public async Task ShouldThrowExceptionOnCommitWhenGraphNotSupportTx()
         {
             var connection = _connectionFactory.CreateRemoteConnection();
-            var g = AnonymousTraversalSource.Traversal().WithRemote(connection);
+            var g = AnonymousTraversalSource.Traversal().With(connection);
             var tx = g.Tx();
             var exception = await Assert.ThrowsAsync<ResponseException>(async () => await tx.CommitAsync());
             Assert.Equal("ServerError: Graph does not support transactions", exception.Message);
@@ -286,7 +286,7 @@ namespace Gremlin.Net.IntegrationTest.Process.Traversal.DriverRemoteConnection
         public async Task ShouldThrowExceptionOnRollbackWhenGraphNotSupportTx()
         {
             var connection = _connectionFactory.CreateRemoteConnection();
-            var g = AnonymousTraversalSource.Traversal().WithRemote(connection);
+            var g = AnonymousTraversalSource.Traversal().With(connection);
             var tx = g.Tx();
             var exception = await Assert.ThrowsAsync<ResponseException>(async () => await tx.RollbackAsync());
             Assert.Equal("ServerError: Graph does not support transactions", exception.Message);
@@ -296,7 +296,7 @@ namespace Gremlin.Net.IntegrationTest.Process.Traversal.DriverRemoteConnection
         public void shouldUseMaterializedPropertiesTokenInV()
         {
             var connection = _connectionFactory.CreateRemoteConnection();
-            var g = AnonymousTraversalSource.Traversal().WithRemote(connection);
+            var g = AnonymousTraversalSource.Traversal().With(connection);
             var vertices = g.With("materializeProperties", "tokens").V().ToList();
             foreach (var v in vertices)
             {
@@ -310,7 +310,7 @@ namespace Gremlin.Net.IntegrationTest.Process.Traversal.DriverRemoteConnection
         public void shouldUseMaterializedPropertiesTokenInE()
         {
             var connection = _connectionFactory.CreateRemoteConnection();
-            var g = AnonymousTraversalSource.Traversal().WithRemote(connection);
+            var g = AnonymousTraversalSource.Traversal().With(connection);
             var edges = g.With("materializeProperties", "tokens").E().ToList();
             foreach (var e in edges)
             {
@@ -324,7 +324,7 @@ namespace Gremlin.Net.IntegrationTest.Process.Traversal.DriverRemoteConnection
         public void shouldUseMaterializedPropertiesTokenInVP()
         {
             var connection = _connectionFactory.CreateRemoteConnection();
-            var g = AnonymousTraversalSource.Traversal().WithRemote(connection);
+            var g = AnonymousTraversalSource.Traversal().With(connection);
             var vps = g.With("materializeProperties", "tokens").V().Properties<VertexProperty>().ToList();
             foreach (var vp in vps)
             {

--- a/gremlin-dotnet/test/Gremlin.Net.IntegrationTest/Process/Traversal/DriverRemoteConnection/GraphTraversalTests.cs
+++ b/gremlin-dotnet/test/Gremlin.Net.IntegrationTest/Process/Traversal/DriverRemoteConnection/GraphTraversalTests.cs
@@ -43,7 +43,7 @@ namespace Gremlin.Net.IntegrationTest.Process.Traversal.DriverRemoteConnection
         public void g_V_Count()
         {
             var connection = _connectionFactory.CreateRemoteConnection();
-            var g = AnonymousTraversalSource.Traversal().WithRemote(connection);
+            var g = AnonymousTraversalSource.Traversal().With(connection);
 
             var count = g.V().Count().Next();
 
@@ -54,7 +54,7 @@ namespace Gremlin.Net.IntegrationTest.Process.Traversal.DriverRemoteConnection
         public void g_V_Has_Count()
         {
             var connection = _connectionFactory.CreateRemoteConnection();
-            var g = AnonymousTraversalSource.Traversal().WithRemote(connection);
+            var g = AnonymousTraversalSource.Traversal().With(connection);
 
             var b = Bindings.Instance;
             var count = g.V().Has("person", "age", b.Of("x", P.Lt(30))).Count().Next();
@@ -66,7 +66,7 @@ namespace Gremlin.Net.IntegrationTest.Process.Traversal.DriverRemoteConnection
         public void g_V_Count_Clone()
         {
             var connection = _connectionFactory.CreateRemoteConnection();
-            var g = AnonymousTraversalSource.Traversal().WithRemote(connection);
+            var g = AnonymousTraversalSource.Traversal().With(connection);
 
             var t = g.V().Count();
 
@@ -79,7 +79,7 @@ namespace Gremlin.Net.IntegrationTest.Process.Traversal.DriverRemoteConnection
         public void g_VX1X_Next()
         {
             var connection = _connectionFactory.CreateRemoteConnection();
-            var g = AnonymousTraversalSource.Traversal().WithRemote(connection);
+            var g = AnonymousTraversalSource.Traversal().With(connection);
 
             var vertex = g.V(1).Next();
 
@@ -91,7 +91,7 @@ namespace Gremlin.Net.IntegrationTest.Process.Traversal.DriverRemoteConnection
         public void g_VX1X_NextTraverser()
         {
             var connection = _connectionFactory.CreateRemoteConnection();
-            var g = AnonymousTraversalSource.Traversal().WithRemote(connection);
+            var g = AnonymousTraversalSource.Traversal().With(connection);
 
             var traverser = g.V(1).NextTraverser();
 
@@ -102,7 +102,7 @@ namespace Gremlin.Net.IntegrationTest.Process.Traversal.DriverRemoteConnection
         public void g_VX1X_ToList()
         {
             var connection = _connectionFactory.CreateRemoteConnection();
-            var g = AnonymousTraversalSource.Traversal().WithRemote(connection);
+            var g = AnonymousTraversalSource.Traversal().With(connection);
 
             var list = g.V(1).ToList();
 
@@ -113,7 +113,7 @@ namespace Gremlin.Net.IntegrationTest.Process.Traversal.DriverRemoteConnection
         public void g_V_RepeatXBothX_TimesX5X_NextX10X()
         {
             var connection = _connectionFactory.CreateRemoteConnection();
-            var g = AnonymousTraversalSource.Traversal().WithRemote(connection);
+            var g = AnonymousTraversalSource.Traversal().With(connection);
 
             var result = g.V().Repeat(__.Both()).Times(5).Next(10);
 
@@ -124,7 +124,7 @@ namespace Gremlin.Net.IntegrationTest.Process.Traversal.DriverRemoteConnection
         public void g_V_RepeatXOutX_TimesX2X_ValuesXNameX()
         {
             var connection = _connectionFactory.CreateRemoteConnection();
-            var g = AnonymousTraversalSource.Traversal().WithRemote(connection);
+            var g = AnonymousTraversalSource.Traversal().With(connection);
 
             var t = g.V().Repeat(__.Out()).Times(2).Values<string>("name");
             var names = t.ToList();
@@ -138,7 +138,7 @@ namespace Gremlin.Net.IntegrationTest.Process.Traversal.DriverRemoteConnection
         public void ShortestPathTest()
         {
             var connection = _connectionFactory.CreateRemoteConnection();
-            var g = AnonymousTraversalSource.Traversal().WithRemote(connection);
+            var g = AnonymousTraversalSource.Traversal().With(connection);
 
             var shortestPath =
                 g.V(5).Repeat(__.Both().SimplePath()).Until(__.HasId(6)).Limit<Vertex>(1).Path().Next();
@@ -151,7 +151,7 @@ namespace Gremlin.Net.IntegrationTest.Process.Traversal.DriverRemoteConnection
         public void ValueMapTest()
         {
             var connection = _connectionFactory.CreateRemoteConnection();
-            var g = AnonymousTraversalSource.Traversal().WithRemote(connection);
+            var g = AnonymousTraversalSource.Traversal().With(connection);
 
             var result = g.V(1).ValueMap<string, IList<object>>().Next();
             Assert.Equal(
@@ -167,7 +167,7 @@ namespace Gremlin.Net.IntegrationTest.Process.Traversal.DriverRemoteConnection
         public void ValueMapWithListConversionTest()
         {
             var connection = _connectionFactory.CreateRemoteConnection();
-            var g = AnonymousTraversalSource.Traversal().WithRemote(connection);
+            var g = AnonymousTraversalSource.Traversal().With(connection);
 
             var result = g.V(1).ValueMap<string, IList<int>>("age").Next();
             Assert.Equal(new Dictionary<string, IList<int>>
@@ -180,7 +180,7 @@ namespace Gremlin.Net.IntegrationTest.Process.Traversal.DriverRemoteConnection
         public void GroupedEdgePropertyConversionTest()
         {
             var connection = _connectionFactory.CreateRemoteConnection();
-            var g = AnonymousTraversalSource.Traversal().WithRemote(connection);
+            var g = AnonymousTraversalSource.Traversal().With(connection);
             var result = g.V().HasLabel("software").Group<string, double>().By("name")
                           .By(__.BothE().Values<double>("weight").Mean<double>()).Next();
             Assert.Equal(new Dictionary<string, double>
@@ -194,7 +194,7 @@ namespace Gremlin.Net.IntegrationTest.Process.Traversal.DriverRemoteConnection
         public void ShouldUseBindingsInTraversal()
         {
             var connection = _connectionFactory.CreateRemoteConnection();
-            var g = AnonymousTraversalSource.Traversal().WithRemote(connection);
+            var g = AnonymousTraversalSource.Traversal().With(connection);
 
             var b = new Bindings();
             var count = g.V().Has(b.Of("propertyKey", "name"), b.Of("propertyValue", "marko")).OutE().Count().Next();
@@ -211,7 +211,7 @@ namespace Gremlin.Net.IntegrationTest.Process.Traversal.DriverRemoteConnection
                 {"x", "test"},
                 {"y", true}
             };
-            var g = AnonymousTraversalSource.Traversal().WithRemote(connection);
+            var g = AnonymousTraversalSource.Traversal().With(connection);
             
             var countWithStrategy = g.WithStrategies(new OptionsStrategy(options)).V().Count().Next();
             Assert.Equal(6, countWithStrategy);
@@ -227,7 +227,7 @@ namespace Gremlin.Net.IntegrationTest.Process.Traversal.DriverRemoteConnection
         public void ShouldUseSeedStrategyToReturnDeterministicResults()
         {
             var connection = _connectionFactory.CreateRemoteConnection();
-            var g = AnonymousTraversalSource.Traversal().WithRemote(connection).WithStrategies(new SeedStrategy(664664));
+            var g = AnonymousTraversalSource.Traversal().With(connection).WithStrategies(new SeedStrategy(664664));
 
             var shuffledResults = g.V().Values<string>("name").Order().By(Order.Shuffle).ToList();
             Assert.Equal(shuffledResults, g.V().Values<string>("name").Order().By(Order.Shuffle).ToList());
@@ -241,7 +241,7 @@ namespace Gremlin.Net.IntegrationTest.Process.Traversal.DriverRemoteConnection
         public async Task ShouldExecuteAsynchronouslyWhenPromiseIsCalled()
         {
             var connection = _connectionFactory.CreateRemoteConnection();
-            var g = AnonymousTraversalSource.Traversal().WithRemote(connection);
+            var g = AnonymousTraversalSource.Traversal().With(connection);
 
             var count = await g.V().Count().Promise(t => t.Next());
 
@@ -252,7 +252,7 @@ namespace Gremlin.Net.IntegrationTest.Process.Traversal.DriverRemoteConnection
         public async Task ShouldSupportCancellationForPromise()
         {
             var connection = _connectionFactory.CreateRemoteConnection();
-            var g = AnonymousTraversalSource.Traversal().WithRemote(connection);
+            var g = AnonymousTraversalSource.Traversal().With(connection);
 
             await Assert.ThrowsAsync<TaskCanceledException>(async () =>
                 await g.V().Promise(t => t.Iterate(), new CancellationToken(true)));
@@ -262,7 +262,7 @@ namespace Gremlin.Net.IntegrationTest.Process.Traversal.DriverRemoteConnection
         public async Task ShouldSupportFurtherTraversalsAfterOneWasCancelled()
         {
             var connection = _connectionFactory.CreateRemoteConnection(connectionPoolSize: 1);
-            var g = AnonymousTraversalSource.Traversal().WithRemote(connection);
+            var g = AnonymousTraversalSource.Traversal().With(connection);
             var cts = new CancellationTokenSource();
             
             var cancelledTask = g.V().Promise(t => t.Iterate(), cts.Token);

--- a/gremlin-dotnet/test/Gremlin.Net.IntegrationTest/Process/Traversal/DriverRemoteConnection/GraphTraversalTransactionTests.cs
+++ b/gremlin-dotnet/test/Gremlin.Net.IntegrationTest/Process/Traversal/DriverRemoteConnection/GraphTraversalTransactionTests.cs
@@ -36,7 +36,7 @@ namespace Gremlin.Net.IntegrationTest.Process.Traversal.DriverRemoteConnection
         [Fact]
         public async Task ShouldSupportRemoteTransactionsCommit()
         {
-            var g = AnonymousTraversalSource.Traversal().WithRemote(_connection);
+            var g = AnonymousTraversalSource.Traversal().With(_connection);
             var tx = g.Tx();
             var gtx = tx.Begin();
             await gtx.AddV("person").Property("name", "jorge").Promise(t => t.Iterate()).ConfigureAwait(false);
@@ -60,7 +60,7 @@ namespace Gremlin.Net.IntegrationTest.Process.Traversal.DriverRemoteConnection
         [Fact]
         public async Task ShouldSupportRemoteTransactionsRollback()
         {
-            var g = AnonymousTraversalSource.Traversal().WithRemote(_connection);
+            var g = AnonymousTraversalSource.Traversal().With(_connection);
             var tx = g.Tx();
             var gtx = tx.Begin();
             await gtx.AddV("person").Property("name", "jorge").Promise(t => t.Iterate()).ConfigureAwait(false);
@@ -86,7 +86,7 @@ namespace Gremlin.Net.IntegrationTest.Process.Traversal.DriverRemoteConnection
 
         private void EmptyGraph()
         {
-            var g = AnonymousTraversalSource.Traversal().WithRemote(_connection);
+            var g = AnonymousTraversalSource.Traversal().With(_connection);
             g.V().Drop().Iterate();
         }
     }

--- a/gremlin-dotnet/test/Gremlin.Net.IntegrationTest/Process/Traversal/DriverRemoteConnection/PredicateTests.cs
+++ b/gremlin-dotnet/test/Gremlin.Net.IntegrationTest/Process/Traversal/DriverRemoteConnection/PredicateTests.cs
@@ -35,7 +35,7 @@ namespace Gremlin.Net.IntegrationTest.Process.Traversal.DriverRemoteConnection
         public void ShouldUsePredicatesCombinedWithPAndInHasStep()
         {
             var connection = _connectionFactory.CreateRemoteConnection();
-            var g = AnonymousTraversalSource.Traversal().WithRemote(connection);
+            var g = AnonymousTraversalSource.Traversal().With(connection);
 
             var count = g.V().Has("age", P.Gt(30).And(P.Lt(35))).Count().Next();
 
@@ -46,7 +46,7 @@ namespace Gremlin.Net.IntegrationTest.Process.Traversal.DriverRemoteConnection
         public void ShouldUsePWithinInHasStep()
         {
             var connection = _connectionFactory.CreateRemoteConnection();
-            var g = AnonymousTraversalSource.Traversal().WithRemote(connection);
+            var g = AnonymousTraversalSource.Traversal().With(connection);
 
             var count = g.V().Has("name", P.Within("josh", "vadas")).Count().Next();
 
@@ -57,7 +57,7 @@ namespace Gremlin.Net.IntegrationTest.Process.Traversal.DriverRemoteConnection
         public void ShouldUsePWithinWithListArgumentInHasStep()
         {
             var connection = _connectionFactory.CreateRemoteConnection();
-            var g = AnonymousTraversalSource.Traversal().WithRemote(connection);
+            var g = AnonymousTraversalSource.Traversal().With(connection);
             var names = new List<string> {"josh", "vadas"};
 
             var count = g.V().Has("name", P.Within(names)).Count().Next();

--- a/gremlin-dotnet/test/Gremlin.Net.IntegrationTest/Process/Traversal/DriverRemoteConnection/StrategiesTests.cs
+++ b/gremlin-dotnet/test/Gremlin.Net.IntegrationTest/Process/Traversal/DriverRemoteConnection/StrategiesTests.cs
@@ -40,7 +40,7 @@ namespace Gremlin.Net.IntegrationTest.Process.Traversal.DriverRemoteConnection
         {
             var connection = _connectionFactory.CreateRemoteConnection();
             var g = AnonymousTraversalSource.Traversal()
-                    .WithRemote(connection)
+                    .With(connection)
                     .WithStrategies(new SubgraphStrategy(vertices: __.HasLabel("person")));
 
             var count = g.V().Count().Next();
@@ -53,7 +53,7 @@ namespace Gremlin.Net.IntegrationTest.Process.Traversal.DriverRemoteConnection
         {
             var connection = _connectionFactory.CreateRemoteConnection();
             var g = AnonymousTraversalSource.Traversal()
-                    .WithRemote(connection)
+                    .With(connection)
                     .WithStrategies(new SubgraphStrategy(vertices: __.HasLabel("person"),
                         edges: __.HasLabel("created")));
 
@@ -67,7 +67,7 @@ namespace Gremlin.Net.IntegrationTest.Process.Traversal.DriverRemoteConnection
         {
             var connection = _connectionFactory.CreateRemoteConnection();
             var g = AnonymousTraversalSource.Traversal()
-                    .WithRemote(connection)
+                    .With(connection)
                     .WithStrategies(new SubgraphStrategy(vertices: __.HasLabel("person")));
 
             var count = g.V().Label().Dedup().Count().Next();
@@ -80,7 +80,7 @@ namespace Gremlin.Net.IntegrationTest.Process.Traversal.DriverRemoteConnection
         {
             var connection = _connectionFactory.CreateRemoteConnection();
             var g = AnonymousTraversalSource.Traversal()
-                    .WithRemote(connection)
+                    .With(connection)
                     .WithStrategies(new SubgraphStrategy(vertices: __.HasLabel("person")));
 
             var label = g.V().Label().Dedup().Next();
@@ -93,7 +93,7 @@ namespace Gremlin.Net.IntegrationTest.Process.Traversal.DriverRemoteConnection
         {
             var connection = _connectionFactory.CreateRemoteConnection();
             var g = AnonymousTraversalSource.Traversal()
-                    .WithRemote(connection)
+                    .With(connection)
                     .WithStrategies(new SubgraphStrategy(vertices: __.Has("name", "marko")));
 
             var count = g.V().Count().Next();
@@ -106,7 +106,7 @@ namespace Gremlin.Net.IntegrationTest.Process.Traversal.DriverRemoteConnection
         {
             var connection = _connectionFactory.CreateRemoteConnection();
             var g = AnonymousTraversalSource.Traversal()
-                    .WithRemote(connection)
+                    .With(connection)
                     .WithStrategies(new SubgraphStrategy(edges: __.Limit<object>(0)));
 
             var count = g.E().Count().Next();
@@ -119,7 +119,7 @@ namespace Gremlin.Net.IntegrationTest.Process.Traversal.DriverRemoteConnection
         {
             var connection = _connectionFactory.CreateRemoteConnection();
             var g = AnonymousTraversalSource.Traversal()
-                    .WithRemote(connection)
+                    .With(connection)
                     .WithStrategies(new SubgraphStrategy(vertices: __.Has("name", "marko")));
 
             var label = g.V().Label().Dedup().Next();
@@ -132,7 +132,7 @@ namespace Gremlin.Net.IntegrationTest.Process.Traversal.DriverRemoteConnection
         {
             var connection = _connectionFactory.CreateRemoteConnection();
             var g = AnonymousTraversalSource.Traversal()
-                    .WithRemote(connection)
+                    .With(connection)
                     .WithStrategies(new SubgraphStrategy(vertices: __.Has("name", "marko")));
 
             var name = g.V().Values<string>("name").Next();
@@ -144,7 +144,7 @@ namespace Gremlin.Net.IntegrationTest.Process.Traversal.DriverRemoteConnection
         public void g_V_Count_Next_WithComputer()
         {
             var connection = _connectionFactory.CreateRemoteConnection();
-            var g = AnonymousTraversalSource.Traversal().WithRemote(connection).WithComputer();
+            var g = AnonymousTraversalSource.Traversal().With(connection).WithComputer();
 
             var count = g.V().Count().Next();
 
@@ -155,7 +155,7 @@ namespace Gremlin.Net.IntegrationTest.Process.Traversal.DriverRemoteConnection
         public void g_E_Count_Next_WithComputer()
         {
             var connection = _connectionFactory.CreateRemoteConnection();
-            var g = AnonymousTraversalSource.Traversal().WithRemote(connection).WithComputer();
+            var g = AnonymousTraversalSource.Traversal().With(connection).WithComputer();
 
             var count = g.E().Count().Next();
 
@@ -166,7 +166,7 @@ namespace Gremlin.Net.IntegrationTest.Process.Traversal.DriverRemoteConnection
         public async Task ShouldThrowWhenModifyingTraversalSourceWithReadOnlyStrategy()
         {
             var connection = _connectionFactory.CreateRemoteConnection();
-            var g = AnonymousTraversalSource.Traversal().WithRemote(connection).WithStrategies(new ReadOnlyStrategy());
+            var g = AnonymousTraversalSource.Traversal().With(connection).WithStrategies(new ReadOnlyStrategy());
 
             await Assert.ThrowsAsync<ResponseException>(async () => await g.AddV("person").Promise(t => t.Next()));
         }
@@ -175,7 +175,7 @@ namespace Gremlin.Net.IntegrationTest.Process.Traversal.DriverRemoteConnection
         public void WithoutStrategiesShouldNeutralizeWithStrategy()
         {
             var connection = _connectionFactory.CreateRemoteConnection();
-            var g = AnonymousTraversalSource.Traversal().WithRemote(connection)
+            var g = AnonymousTraversalSource.Traversal().With(connection)
                 .WithStrategies(new SubgraphStrategy(vertices: __.HasLabel("person")))
                 .WithoutStrategies(typeof(SubgraphStrategy));
 

--- a/gremlin-dotnet/test/Gremlin.Net.Template.IntegrationTest/ServiceTests.cs
+++ b/gremlin-dotnet/test/Gremlin.Net.Template.IntegrationTest/ServiceTests.cs
@@ -43,7 +43,7 @@ namespace Gremlin.Net.Template.IntegrationTest
         {
             using (var client = CreateClient())
             {
-                var g = Traversal().WithRemote(new DriverRemoteConnection(client, TestTraversalSource));
+                var g = Traversal().With(new DriverRemoteConnection(client, TestTraversalSource));
                 var service = new Service(g);
             
                 var creators = service.FindCreatorsOfSoftware("lop");

--- a/gremlin-dotnet/test/Gremlin.Net.UnitTest/Process/Remote/RemoteTransactionTests.cs
+++ b/gremlin-dotnet/test/Gremlin.Net.UnitTest/Process/Remote/RemoteTransactionTests.cs
@@ -36,7 +36,7 @@ namespace Gremlin.Net.UnitTest.Process.Remote
         public void ShouldNotAllowBeginMoreThanOnce()
         {
             var g = AnonymousTraversalSource.Traversal()
-                .WithRemote(new DriverRemoteConnection(Substitute.For<IGremlinClient>()));
+                .With(new DriverRemoteConnection(Substitute.For<IGremlinClient>()));
             var tx = g.Tx();
             tx.Begin();
 
@@ -47,7 +47,7 @@ namespace Gremlin.Net.UnitTest.Process.Remote
         public void ShouldNotSupportChildTransactions()
         {
             var g = AnonymousTraversalSource.Traversal()
-                .WithRemote(new DriverRemoteConnection(Substitute.For<IGremlinClient>()));
+                .With(new DriverRemoteConnection(Substitute.For<IGremlinClient>()));
             var tx = g.Tx();
             
             var gtx = tx.Begin();

--- a/gremlin-dotnet/test/Gremlin.Net.UnitTest/Process/Traversal/GraphTraversalSourceTests.cs
+++ b/gremlin-dotnet/test/Gremlin.Net.UnitTest/Process/Traversal/GraphTraversalSourceTests.cs
@@ -32,9 +32,9 @@ namespace Gremlin.Net.UnitTest.Process.Traversal
     public class GraphTraversalSourceTests
     {
         [Fact]
-        public void ShouldBeIndependentFromReturnedGraphTraversalModififyingBytecode()
+        public void ShouldBeIndependentFromReturnedGraphTraversalModifyingBytecode()
         {
-            var g = AnonymousTraversalSource.Traversal();
+            var g = AnonymousTraversalSource.Traversal().With(null);
 
             g.V().Has("someKey", "someValue").Drop();
 
@@ -43,9 +43,9 @@ namespace Gremlin.Net.UnitTest.Process.Traversal
         }
 
         [Fact]
-        public void ShouldBeIndependentFromReturnedGraphTraversalSourceModififyingBytecode()
+        public void ShouldBeIndependentFromReturnedGraphTraversalSourceModifyingBytecode()
         {
-            var g1 = AnonymousTraversalSource.Traversal();
+            var g1 = AnonymousTraversalSource.Traversal().With(null);
 
             var g2 = g1.WithSideEffect("someSideEffectKey", "someSideEffectValue");
 
@@ -55,20 +55,9 @@ namespace Gremlin.Net.UnitTest.Process.Traversal
         }
 
         [Fact]
-        public void ShouldBeIndependentFromReturnedGraphTraversalSourceModififyingTraversalStrategies()
+        public void CloneShouldCreateIndependentGraphTraversalModifyingBytecode()
         {
-            var gLocal = AnonymousTraversalSource.Traversal();
-
-            var gRemote = gLocal.WithRemote(Substitute.For<IRemoteConnection>());
-
-            Assert.Equal(0, gLocal.TraversalStrategies.Count);
-            Assert.Equal(1, gRemote.TraversalStrategies.Count);
-        }
-
-        [Fact]
-        public void CloneShouldCreateIndependentGraphTraversalModifiyingBytecode()
-        {
-            var g = AnonymousTraversalSource.Traversal();
+            var g = AnonymousTraversalSource.Traversal().With(null);
             var original = g.V().Out("created");
             var clone = original.Clone().Out("knows");
             var cloneClone = clone.Clone().Out("created");
@@ -88,7 +77,7 @@ namespace Gremlin.Net.UnitTest.Process.Traversal
         [Fact]
         public void ShouldOnlyAllowChildTraversalsThatAreAnonymous()
         {
-            var g = AnonymousTraversalSource.Traversal();
+            var g = AnonymousTraversalSource.Traversal().With(null);
 
             g.V(0).AddE("self").To(__.V(1));
 

--- a/gremlin-dotnet/test/Gremlin.Net.UnitTest/Process/Traversal/Translator/GroovyTranslatorTests.cs
+++ b/gremlin-dotnet/test/Gremlin.Net.UnitTest/Process/Traversal/Translator/GroovyTranslatorTests.cs
@@ -35,8 +35,8 @@ namespace Gremlin.Net.UnitTest.Process.Traversal.Translator;
 
 public class GroovyTranslatorTests
 {
-    private readonly GraphTraversalSource _g = AnonymousTraversalSource.Traversal();
-
+    private readonly GraphTraversalSource _g = AnonymousTraversalSource.Traversal().With(null);
+    
     [Fact]
     public void ShouldTranslateStepsWithSingleArguments()
     {

--- a/gremlin-go/README.md
+++ b/gremlin-go/README.md
@@ -59,7 +59,7 @@ func main() {
 	defer driverRemoteConnection.Close()
 
 	// Create an anonymous traversal source with remote
-	g := gremlingo.Traversal_().WithRemote(driverRemoteConnection)
+	g := gremlingo.Traversal_().With(driverRemoteConnection)
 
 	// Add a vertex with properties to the graph with the terminal step Iterate()
 	promise := g.AddV("gremlin").Property("language", "go").Iterate()

--- a/gremlin-go/driver/anonymousTraversal.go
+++ b/gremlin-go/driver/anonymousTraversal.go
@@ -21,7 +21,12 @@ package gremlingo
 
 // AnonymousTraversalSource interface for generating anonymous traversals.
 type AnonymousTraversalSource interface {
+	// With used to set the DriverRemoteConnection within the AnonymousTraversalSource
+	With(drc *DriverRemoteConnection) *GraphTraversalSource
+
 	// WithRemote used to set the DriverRemoteConnection within the AnonymousTraversalSource
+	//
+	// Deprecated: WithRemote replaced by With
 	WithRemote(drc *DriverRemoteConnection) *GraphTraversalSource
 }
 
@@ -31,7 +36,14 @@ type anonymousTraversalSource struct {
 
 var traversalSource = &anonymousTraversalSource{}
 
+// With used to set the DriverRemoteConnection within the AnonymousTraversalSource.
+func (ats *anonymousTraversalSource) With(drc *DriverRemoteConnection) *GraphTraversalSource {
+	return NewDefaultGraphTraversalSource().WithRemote(drc)
+}
+
 // WithRemote used to set the DriverRemoteConnection within the AnonymousTraversalSource.
+//
+// Deprecated: WithRemote replaced by With
 func (ats *anonymousTraversalSource) WithRemote(drc *DriverRemoteConnection) *GraphTraversalSource {
 	return NewDefaultGraphTraversalSource().WithRemote(drc)
 }

--- a/gremlin-go/driver/connection_test.go
+++ b/gremlin-go/driver/connection_test.go
@@ -101,7 +101,7 @@ func getTestGraph(t *testing.T, url string, auth AuthInfoProvider, tls *tls.Conf
 		})
 	assert.Nil(t, err)
 	assert.NotNil(t, remote)
-	g := Traversal_().WithRemote(remote)
+	g := Traversal_().With(remote)
 
 	return g
 }
@@ -816,7 +816,7 @@ func TestConnection(t *testing.T) {
 		// Close remote connection.
 		defer remote.Close()
 
-		g := Traversal_().WithRemote(remote)
+		g := Traversal_().With(remote)
 
 		// Drop the graph and check that it is empty.
 		dropGraph(t, g)
@@ -936,7 +936,7 @@ func TestConnection(t *testing.T) {
 		assert.NotNil(t, remote)
 		defer remote.Close()
 
-		g := Traversal_().WithRemote(remote)
+		g := Traversal_().With(remote)
 
 		r, err := g.V().Count().ToList()
 		assert.Nil(t, err)
@@ -1069,7 +1069,7 @@ func TestConnection(t *testing.T) {
 		assert.Nil(t, err)
 		assert.NotNil(t, remote)
 		defer remote.Close()
-		g := Traversal_().WithRemote(remote)
+		g := Traversal_().With(remote)
 
 		r, err := g.V((&Bindings{}).Of("x", 1)).Out("created").Map(&Lambda{Script: "it.get().value('name').length()", Language: ""}).Sum().ToList()
 		assert.Nil(t, err)

--- a/gremlin-go/driver/cucumber/cucumberSteps_test.go
+++ b/gremlin-go/driver/cucumber/cucumberSteps_test.go
@@ -399,7 +399,7 @@ func (tg *tinkerPopGraph) nothingShouldHappenBecause(arg1 *godog.DocString) erro
 func (tg *tinkerPopGraph) chooseGraph(graphName string) error {
 	tg.graphName = graphName
 	data := tg.graphDataMap[graphName]
-	tg.g = gremlingo.Traversal_().WithRemote(data.connection)
+	tg.g = gremlingo.Traversal_().With(data.connection)
 	if graphName == "empty" {
 		err := tg.cleanEmptyDataGraph(tg.g)
 		if err != nil {

--- a/gremlin-go/driver/cucumber/cucumberWorld.go
+++ b/gremlin-go/driver/cucumber/cucumberWorld.go
@@ -106,7 +106,7 @@ func (t *CucumberWorld) loadAllDataGraph() {
 			if err != nil {
 				panic(fmt.Sprintf("Failed to create connection '%v'", err))
 			}
-			g := gremlingo.Traversal_().WithRemote(connection)
+			g := gremlingo.Traversal_().With(connection)
 			t.graphDataMap[name] = &DataGraph{
 				name:             name,
 				connection:       connection,
@@ -127,7 +127,7 @@ func (t *CucumberWorld) loadEmptyDataGraph() {
 
 func (t *CucumberWorld) reloadEmptyData() {
 	graphData := t.getDataGraphFromMap("empty")
-	g := gremlingo.Traversal_().WithRemote(graphData.connection)
+	g := gremlingo.Traversal_().With(graphData.connection)
 	graphData.vertices = getVertices(g)
 	graphData.edges = getEdges(g)
 }

--- a/gremlin-go/driver/performance/performanceSuite.go
+++ b/gremlin-go/driver/performance/performanceSuite.go
@@ -389,7 +389,7 @@ func createConnection(host string, port, poolSize, buffersSize int) (*GraphTrave
 	if err != nil {
 		log.Fatalln(err)
 	} else {
-		g = gremlingo.Traversal_().WithRemote(drc)
+		g = gremlingo.Traversal_().With(drc)
 	}
 	return g, drc, err
 }

--- a/gremlin-go/driver/strategies_test.go
+++ b/gremlin-go/driver/strategies_test.go
@@ -35,7 +35,7 @@ func getModernGraph(t *testing.T, url string, auth AuthInfoProvider, tls *tls.Co
 		})
 	assert.Nil(t, err)
 	assert.NotNil(t, remote)
-	g := Traversal_().WithRemote(remote)
+	g := Traversal_().With(remote)
 
 	return g
 }

--- a/gremlin-go/driver/traversal_test.go
+++ b/gremlin-go/driver/traversal_test.go
@@ -77,7 +77,7 @@ func TestTraversal(t *testing.T) {
 	t.Run("Test Transaction commit", func(t *testing.T) {
 		// Start a transaction traversal.
 		remote := newConnection(t)
-		g := Traversal_().WithRemote(remote)
+		g := Traversal_().With(remote)
 		startCount := getCount(t, g)
 		tx := g.Tx()
 
@@ -106,7 +106,7 @@ func TestTraversal(t *testing.T) {
 	t.Run("Test Transaction rollback", func(t *testing.T) {
 		// Start a transaction traversal.
 		remote := newConnection(t)
-		g := Traversal_().WithRemote(remote)
+		g := Traversal_().With(remote)
 		startCount := getCount(t, g)
 		tx := g.Tx()
 
@@ -135,7 +135,7 @@ func TestTraversal(t *testing.T) {
 	t.Run("Test Transaction flows", func(t *testing.T) {
 		// Start a transaction traversal.
 		remote := newConnection(t)
-		g := Traversal_().WithRemote(remote)
+		g := Traversal_().With(remote)
 		tx := g.Tx()
 		assert.False(t, tx.IsOpen())
 
@@ -181,7 +181,7 @@ func TestTraversal(t *testing.T) {
 	t.Run("Test multi commit Transaction", func(t *testing.T) {
 		// Start a transaction traversal.
 		remote := newConnection(t)
-		g := Traversal_().WithRemote(remote)
+		g := Traversal_().With(remote)
 		startCount := getCount(t, g)
 
 		// Create two transactions.
@@ -215,7 +215,7 @@ func TestTraversal(t *testing.T) {
 	t.Run("Test multi rollback Transaction", func(t *testing.T) {
 		// Start a transaction traversal.
 		remote := newConnection(t)
-		g := Traversal_().WithRemote(remote)
+		g := Traversal_().With(remote)
 		startCount := getCount(t, g)
 
 		// Create two transactions.
@@ -249,7 +249,7 @@ func TestTraversal(t *testing.T) {
 	t.Run("Test multi commit and rollback Transaction", func(t *testing.T) {
 		// Start a transaction traversal.
 		remote := newConnection(t)
-		g := Traversal_().WithRemote(remote)
+		g := Traversal_().With(remote)
 		startCount := getCount(t, g)
 
 		// Create two transactions.
@@ -283,7 +283,7 @@ func TestTraversal(t *testing.T) {
 	t.Run("Test Transaction close", func(t *testing.T) {
 		// Start a transaction traversal.
 		remote := newConnection(t)
-		g := Traversal_().WithRemote(remote)
+		g := Traversal_().With(remote)
 		dropGraphCheckCount(t, g)
 
 		// Create two transactions.
@@ -311,14 +311,14 @@ func TestTraversal(t *testing.T) {
 		verifyGtxClosed(t, gtx2)
 
 		remote = newConnection(t)
-		g = Traversal_().WithRemote(remote)
+		g = Traversal_().With(remote)
 		assert.Equal(t, int32(0), getCount(t, g))
 	})
 
 	t.Run("Test Transaction close tx from parent", func(t *testing.T) {
 		// Start a transaction traversal.
 		remote := newConnection(t)
-		g := Traversal_().WithRemote(remote)
+		g := Traversal_().With(remote)
 		dropGraphCheckCount(t, g)
 
 		// Create two transactions.
@@ -348,7 +348,7 @@ func TestTraversal(t *testing.T) {
 		verifyGtxClosed(t, gtx2)
 
 		remote = newConnection(t)
-		g = Traversal_().WithRemote(remote)
+		g = Traversal_().With(remote)
 		assert.Equal(t, int32(0), getCount(t, g))
 	})
 
@@ -541,7 +541,7 @@ func newWithOptionsConnection(t *testing.T) *GraphTraversalSource {
 		})
 	assert.Nil(t, err)
 	assert.NotNil(t, remote)
-	return Traversal_().WithRemote(remote)
+	return Traversal_().With(remote)
 }
 
 func newConnection(t *testing.T) *DriverRemoteConnection {

--- a/gremlin-go/examples/connections.go
+++ b/gremlin-go/examples/connections.go
@@ -43,8 +43,8 @@ func withRemote() {
 	// Cleanup
 	defer driverRemoteConnection.Close()
 
-    // Creating the graph traversal
-	g := gremlingo.Traversal_().WithRemote(driverRemoteConnection)
+	// Creating graph traversal
+	g := gremlingo.Traversal_().With(driverRemoteConnection)
 
     // Drop existing vertices
     prom := g.V().Drop().Iterate()

--- a/gremlin-javascript/src/main/javascript/gremlin-javascript/README.md
+++ b/gremlin-javascript/src/main/javascript/gremlin-javascript/README.md
@@ -44,7 +44,7 @@ const gremlin = require('gremlin');
 const traversal = gremlin.process.AnonymousTraversalSource.traversal;
 const DriverRemoteConnection = gremlin.driver.DriverRemoteConnection;
 
-const g = traversal().withRemote(new DriverRemoteConnection('ws://localhost:8182/gremlin'));
+const g = traversal().with_(new DriverRemoteConnection('ws://localhost:8182/gremlin'));
 ```
 
 Once "g" has been created using a connection, it is then possible to start writing Gremlin traversals to query the 

--- a/gremlin-javascript/src/main/javascript/gremlin-javascript/lib/process/graph-traversal.js
+++ b/gremlin-javascript/src/main/javascript/gremlin-javascript/lib/process/graph-traversal.js
@@ -24,7 +24,6 @@
 
 const { Traversal, cardinality } = require('./traversal');
 const { Transaction } = require('./transaction');
-const remote = require('../driver/remote-connection');
 const Bytecode = require('./bytecode');
 const { TraversalStrategies, VertexProgramStrategy, OptionsStrategy } = require('./traversal-strategy');
 
@@ -46,28 +45,8 @@ class GraphTraversalSource {
     this.bytecode = bytecode || new Bytecode();
     this.graphTraversalSourceClass = graphTraversalSourceClass || GraphTraversalSource;
     this.graphTraversalClass = graphTraversalClass || GraphTraversal;
-
-    // in order to keep the constructor unchanged within 3.5.x we can try to pop the RemoteConnection out of the
-    // TraversalStrategies. keeping this unchanged will allow user DSLs to not take a break.
-    // TODO: refactor this to be nicer in 3.6.0 when we can take a breaking change
     const strat = traversalStrategies.strategies.find((ts) => ts.fqcn === 'js:RemoteStrategy');
     this.remoteConnection = strat !== undefined ? strat.connection : undefined;
-  }
-
-  /**
-   * @param {RemoteConnection} remoteConnection
-   * @returns {GraphTraversalSource}
-   */
-  withRemote(remoteConnection) {
-    const traversalStrategy = new TraversalStrategies(this.traversalStrategies);
-    traversalStrategy.addStrategy(new remote.RemoteStrategy(remoteConnection));
-    return new this.graphTraversalSourceClass(
-      this.graph,
-      traversalStrategy,
-      new Bytecode(this.bytecode),
-      this.graphTraversalSourceClass,
-      this.graphTraversalClass,
-    );
   }
 
   /**

--- a/gremlin-javascript/src/main/javascript/gremlin-javascript/test/cucumber/feature-steps.js
+++ b/gremlin-javascript/src/main/javascript/gremlin-javascript/test/cucumber/feature-steps.js
@@ -139,7 +139,7 @@ Given(/^the (.+) graph$/, function (graphName) {
   }
   this.graphName = graphName;
   const data = this.getData();
-  this.g = traversal().withRemote(data.connection);
+  this.g = traversal().with_(data.connection);
 
   if (this.isGraphComputer) {
     this.g = this.g.withComputer();

--- a/gremlin-javascript/src/main/javascript/gremlin-javascript/test/integration/sasl-authentication-tests.js
+++ b/gremlin-javascript/src/main/javascript/gremlin-javascript/test/integration/sasl-authentication-tests.js
@@ -105,7 +105,7 @@ describe('DriverRemoteConnection', function () {
           rejectUnauthorized: false
         });
 
-        const g = traversal().withRemote(connection);
+        const g = traversal().with_(connection);
         return g.V().toList().then(function() {
           assert.fail("server is running TLS and trying to connect with ws:// so this should result in error thrown");
         }).catch(function(err) {

--- a/gremlin-javascript/src/main/javascript/gremlin-javascript/test/integration/traversal-test.js
+++ b/gremlin-javascript/src/main/javascript/gremlin-javascript/test/integration/traversal-test.js
@@ -76,7 +76,7 @@ describe('Traversal', function () {
   });
   describe("#construct", function () {
     it('should not hang if server not present', function() {
-      const g = traversal().withRemote(helper.getDriverRemoteConnection('ws://localhost:9998/gremlin', {traversalSource: 'g'}));
+      const g = traversal().with_(helper.getDriverRemoteConnection('ws://localhost:9998/gremlin', {traversalSource: 'g'}));
       return g.V().toList().then(function() {
         assert.fail("there is no server so an error should have occurred");
       }).catch(function(err) {
@@ -87,7 +87,7 @@ describe('Traversal', function () {
   });
   describe('#toList()', function () {
     it('should submit the traversal and return a list', function () {
-      var g = traversal().withRemote(connection);
+      var g = traversal().with_(connection);
       return g.V().toList().then(function (list) {
         assert.ok(list);
         assert.strictEqual(list.length, 6);
@@ -97,7 +97,7 @@ describe('Traversal', function () {
   });
   describe('#clone()', function () {
     it('should reset a traversal when cloned', function () {
-      var g = traversal().withRemote(connection);
+      var g = traversal().with_(connection);
       var t = g.V().count();
       return t.next().then(function (item1) {
         assert.ok(item1);
@@ -111,7 +111,7 @@ describe('Traversal', function () {
   });
   describe('#next()', function () {
     it('should submit the traversal and return an iterator', function () {
-      var g = traversal().withRemote(connection);
+      var g = traversal().with_(connection);
       var t = g.V().count();
       return t.hasNext()
         .then(function (more) {
@@ -161,7 +161,7 @@ describe('Traversal', function () {
   });
   describe('lambdas', function() {
     it('should handle 1-arg lambdas', function() {
-      const g = traversal().withRemote(connection);
+      const g = traversal().with_(connection);
       return g.V().has('person','name','marko').values('name').map(() => "it.get()[1]").toList().then(function (s) {
         assert.ok(s);
         assert.strictEqual(s[0], 'a');
@@ -170,7 +170,7 @@ describe('Traversal', function () {
   });
   describe('dsl', function() {
     it('should expose DSL methods', function() {
-      const g = traversal(SocialTraversalSource).withRemote(connection);
+      const g = traversal(SocialTraversalSource).with_(connection);
       return g.person('marko').aged(29).values('name').toList().then(function (list) {
           assert.ok(list);
           assert.strictEqual(list.length, 1);
@@ -179,7 +179,7 @@ describe('Traversal', function () {
     });
 
     it('should expose anonymous DSL methods', function() {
-      const g = traversal(SocialTraversalSource).withRemote(connection);
+      const g = traversal(SocialTraversalSource).with_(connection);
       return g.person('marko').filter(aged(29)).values('name').toList().then(function (list) {
         assert.ok(list);
         assert.strictEqual(list.length, 1);
@@ -189,7 +189,7 @@ describe('Traversal', function () {
   });
   describe("more complex traversals", function() {
     it('should return paths of value maps', function() {
-      const g = traversal().withRemote(connection);
+      const g = traversal().with_(connection);
       return g.V(1).out().order().in_().order().limit(1).path().by(__.valueMap('name')).toList().then(function (list) {
         assert.ok(list);
         assert.strictEqual(list.length, 1);
@@ -201,7 +201,7 @@ describe('Traversal', function () {
   });
   describe("should allow TraversalStrategy definition", function() {
     it('should allow SubgraphStrategy', function() {
-      const g = traversal().withRemote(connection).withStrategies(
+      const g = traversal().with_(connection).withStrategies(
           new SubgraphStrategy({vertices:__.hasLabel("person"), edges:__.hasLabel("created")}));
       g.V().count().next().then(function (item1) {
         assert.ok(item1);
@@ -221,15 +221,15 @@ describe('Traversal', function () {
       }, (err) => assert.fail("tanked: " + err));
     });
     it('should allow ReadOnlyStrategy', function() {
-      const g = traversal().withRemote(connection).withStrategies(new ReadOnlyStrategy());
+      const g = traversal().with_(connection).withStrategies(new ReadOnlyStrategy());
       return g.addV().iterate().then(() => assert.fail("should have tanked"), (err) => assert.ok(err));
     });
     it('should allow ReservedKeysVerificationStrategy', function() {
-      const g = traversal().withRemote(connection).withStrategies(new ReservedKeysVerificationStrategy(false, true));
+      const g = traversal().with_(connection).withStrategies(new ReservedKeysVerificationStrategy(false, true));
       return g.addV().property("id", "please-don't-use-id").iterate().then(() => assert.fail("should have tanked"), (err) => assert.ok(err));
     });
     it('should allow EdgeLabelVerificationStrategy', function() {
-      const g = traversal().withRemote(connection).withStrategies(new EdgeLabelVerificationStrategy(false, true));
+      const g = traversal().with_(connection).withStrategies(new EdgeLabelVerificationStrategy(false, true));
       g.V().outE("created", "knows").count().next().then(function (item1) {
         assert.ok(item1);
         assert.strictEqual(item1.value, 6);
@@ -237,11 +237,11 @@ describe('Traversal', function () {
       return g.V().out().iterate().then(() => assert.fail("should have tanked"), (err) => assert.strictEqual(err.statusCode, 500));
     });
     it('should allow with_(evaluationTimeout,10)', function() {
-      const g = traversal().withRemote(connection).with_('x').with_('evaluationTimeout', 10);
+      const g = traversal().with_(connection).with_('x').with_('evaluationTimeout', 10);
       return g.V().repeat(__.both()).iterate().then(() => assert.fail("should have tanked"), (err) => assert.strictEqual(err.statusCode, 598));
     });
     it('should allow SeedStrategy', function () {
-      const g = traversal().withRemote(connection).withStrategies(new SeedStrategy({seed: 999999}));
+      const g = traversal().with_(connection).withStrategies(new SeedStrategy({seed: 999999}));
       return g.V().coin(0.4).count().next().then(function (item1) {
         assert.ok(item1);
         assert.strictEqual(item1.value, 1);
@@ -280,13 +280,13 @@ describe('Traversal', function () {
       return txConnection.open();
     });
     after(function () {
-      const g = traversal().withRemote(txConnection);
+      const g = traversal().with_(txConnection);
       return g.V().drop().iterate().then(() => {
         return txConnection.close()
       });
     });
     it('should commit a simple transaction', async function () {
-      const g = traversal().withRemote(txConnection);
+      const g = traversal().with_(txConnection);
       const tx = g.tx();
       const gtx = tx.begin();
       await Promise.all([
@@ -319,13 +319,13 @@ describe('Traversal', function () {
       return txConnection.open();
     });
     after(function () {
-      const g = traversal().withRemote(txConnection);
+      const g = traversal().with_(txConnection);
       return g.V().drop().iterate().then(() => {
         return txConnection.close()
       });
     });
     it('should rollback a simple transaction', async function() {
-      const g = traversal().withRemote(txConnection);
+      const g = traversal().with_(txConnection);
       const tx = g.tx();
       const gtx = tx.begin();
       await Promise.all([

--- a/gremlin-javascript/src/main/javascript/gremlin-javascript/test/unit/traversal-test.js
+++ b/gremlin-javascript/src/main/javascript/gremlin-javascript/test/unit/traversal-test.js
@@ -38,7 +38,7 @@ describe('Traversal', function () {
 
   describe('#getByteCode()', function () {
     it('should add steps for with a string parameter', function () {
-      const g = anon.traversal().withGraph(new graph.Graph());
+      const g = anon.traversal().with_(new graph.Graph());
       const bytecode = g.V().out('created').getBytecode();
       assert.ok(bytecode);
       assert.strictEqual(bytecode.sourceInstructions.length, 0);
@@ -49,7 +49,7 @@ describe('Traversal', function () {
     });
 
     it('should add steps with an enum value', function () {
-      const g = anon.traversal().withGraph(new graph.Graph());
+      const g = anon.traversal().with_(new graph.Graph());
       const bytecode = g.V().order().by('age', t.order.desc).getBytecode();
       assert.ok(bytecode);
       assert.strictEqual(bytecode.sourceInstructions.length, 0);
@@ -64,7 +64,7 @@ describe('Traversal', function () {
     });
 
     it('should add steps with Direction aliases from_ and to properly mapped to OUT and IN', function () {
-      const g = anon.traversal().withGraph(new graph.Graph());
+      const g = anon.traversal().with_(new graph.Graph());
       const bytecode = g.V().to(t.direction.from_, 'knows').to(t.direction.in, 'created').getBytecode();
       assert.ok(bytecode);
       assert.strictEqual(bytecode.sourceInstructions.length, 0);
@@ -253,7 +253,7 @@ describe('Traversal', function () {
 
   describe("build", function() {
     it('should only allow anonymous child traversals', function() {
-      const g = anon.traversal().withGraph(new graph.Graph());
+      const g = anon.traversal().with_(new graph.Graph());
       assert.doesNotThrow(function() {
         g.V(0).addE("self").to(V(1))
       });
@@ -266,7 +266,7 @@ describe('Traversal', function () {
 
   describe('child transactions', function() {
     it('should not support child transactions', function() {
-      const g = anon.traversal().withRemote(new MockRemoteConnection());
+      const g = anon.traversal().with_(new MockRemoteConnection());
       const tx = g.tx();
       assert.throws(function() {
         tx.begin().tx();
@@ -299,7 +299,7 @@ describe('Traversal', function () {
 
   describe('tx#begin()', function() {
     it("should not allow a transaction to begin more than once", function() {
-      const g = anon.traversal().withRemote(new MockRemoteConnection());
+      const g = anon.traversal().with_(new MockRemoteConnection());
       const tx = g.tx();
       tx.begin();
       assert.throws(function () {

--- a/gremlin-python/src/main/python/gremlin_python/process/anonymous_traversal.py
+++ b/gremlin-python/src/main/python/gremlin_python/process/anonymous_traversal.py
@@ -36,25 +36,22 @@ class AnonymousTraversalSource(object):
     def traversal(cls, traversal_source_class=GraphTraversalSource):
         return AnonymousTraversalSource(traversal_source_class)
 
-    def withGraph(self, graph):
-        warnings.warn(
-            "gremlin_python.process.AnonymousTraversalSource.withGraph will be replaced by "
-            "gremlin_python.process.AnonymousTraversalSource.with_graph.",
-            DeprecationWarning)
-        return self.with_graph(graph)
-
-    def with_graph(self, graph):
-        return self.traversal_source_class(graph, TraversalStrategies.global_cache[graph.__class__])
+    def with_(self, remote_connection):
+        return self.traversal_source_class(Graph(), TraversalStrategies(), None, remote_connection)
 
     def withRemote(self, remote_connection):
         warnings.warn(
             "gremlin_python.process.AnonymousTraversalSource.withRemote will be replaced by "
-            "gremlin_python.process.AnonymousTraversalSource.with_remote.",
+            "gremlin_python.process.AnonymousTraversalSource.with_.",
             DeprecationWarning)
-        return self.with_remote(remote_connection)
+        return self.with_(remote_connection)
 
     def with_remote(self, remote_connection):
-        return self.with_graph(Graph()).with_remote(remote_connection)
+        warnings.warn(
+            "gremlin_python.process.AnonymousTraversalSource.with_remote will be replaced by "
+            "gremlin_python.process.AnonymousTraversalSource.with_.",
+            DeprecationWarning)
+        return self.with_(remote_connection)
 
 
 def traversal(traversal_source_class=GraphTraversalSource):

--- a/gremlin-python/src/main/python/gremlin_python/process/graph_traversal.py
+++ b/gremlin-python/src/main/python/gremlin_python/process/graph_traversal.py
@@ -35,7 +35,7 @@ __author__ = 'Stephen Mallette (http://stephen.genoprime.com), Lyndon Bauto (lyn
 
 
 class GraphTraversalSource(object):
-    def __init__(self, graph, traversal_strategies, bytecode=None):
+    def __init__(self, graph, traversal_strategies, bytecode=None, remote_connection=None):
         log.info("Creating GraphTraversalSource.")
         self.graph = graph
         self.traversal_strategies = traversal_strategies
@@ -43,7 +43,9 @@ class GraphTraversalSource(object):
             bytecode = Bytecode()
         self.bytecode = bytecode
         self.graph_traversal = GraphTraversal
-        self.remote_connection = None
+        if remote_connection:
+            self.traversal_strategies.add_strategies([RemoteStrategy(remote_connection)])
+        self.remote_connection = remote_connection
 
     def __repr__(self):
         return "graphtraversalsource[" + str(self.graph) + "]"
@@ -138,19 +140,6 @@ class GraphTraversalSource(object):
         else:
             options_strategy[1].configuration[k] = val
 
-        return source
-
-    def withRemote(self, remote_connection):
-        warnings.warn(
-            "gremlin_python.process.GraphTraversalSource.withRemote will be replaced by "
-            "gremlin_python.process.GraphTraversalSource.with_remote.",
-            DeprecationWarning)
-        return self.with_remote(remote_connection)
-
-    def with_remote(self, remote_connection):
-        source = self.get_graph_traversal_source()
-        source.traversal_strategies.add_strategies([RemoteStrategy(remote_connection)])
-        self.remote_connection = remote_connection
         return source
 
     def tx(self):

--- a/gremlin-python/src/main/python/gremlin_python/process/strategies.py
+++ b/gremlin-python/src/main/python/gremlin_python/process/strategies.py
@@ -19,7 +19,7 @@
 
 __author__ = 'Marko A. Rodriguez (http://markorodriguez.com)'
 
-from gremlin_python.process.traversal import TraversalStrategy
+from .traversal import TraversalStrategy
 
 base_namespace = 'org.apache.tinkerpop.gremlin.process.traversal.strategy.'
 decoration_namespace = base_namespace + 'decoration.'

--- a/gremlin-python/src/main/python/gremlin_python/process/traversal.py
+++ b/gremlin-python/src/main/python/gremlin_python/process/traversal.py
@@ -688,7 +688,6 @@ TRAVERSAL STRATEGIES
 
 
 class TraversalStrategies(object):
-    global_cache = {}
 
     def __init__(self, traversal_strategies=None):
         self.traversal_strategies = traversal_strategies.traversal_strategies if traversal_strategies is not None else []

--- a/gremlin-python/src/main/python/gremlin_python/structure/graph.py
+++ b/gremlin-python/src/main/python/gremlin_python/structure/graph.py
@@ -25,18 +25,6 @@ import warnings
 
 
 class Graph(object):
-    def __init__(self):
-        if self.__class__ not in TraversalStrategies.global_cache:
-            TraversalStrategies.global_cache[self.__class__] = TraversalStrategies()
-
-    def traversal(self, traversal_source_class=None):
-        warnings.warn(
-            "As of release 3.3.5, replaced by the gremlin_python.process.anonymous_traversal.traversal() function.",
-            DeprecationWarning)
-
-        if not traversal_source_class:
-            traversal_source_class = GraphTraversalSource
-        return traversal_source_class(self, TraversalStrategies.global_cache[self.__class__])
 
     def __repr__(self):
         return "graph[]"

--- a/gremlin-python/src/main/python/radish/feature_steps.py
+++ b/gremlin-python/src/main/python/radish/feature_steps.py
@@ -41,7 +41,7 @@ ignores = []
 @given("the {graph_name:w} graph")
 def choose_graph(step, graph_name):
     step.context.graph_name = graph_name
-    step.context.g = traversal().withRemote(step.context.remote_conn[graph_name])
+    step.context.g = traversal().with_(step.context.remote_conn[graph_name])
 
 
 @given("the graph initializer of")

--- a/gremlin-python/src/main/python/radish/terrain.py
+++ b/gremlin-python/src/main/python/radish/terrain.py
@@ -75,7 +75,7 @@ def prepare_traversal_source(scenario):
     remote = __create_remote("ggraph")
     scenario.context.remote_conn["empty"] = remote
     scenario.context.traversals = world.gremlins.get(scenario.sentence, None)
-    g = traversal().withRemote(remote)
+    g = traversal().with_(remote)
     g.V().drop().iterate()
 
 

--- a/gremlin-python/src/main/python/radish/utils.py
+++ b/gremlin-python/src/main/python/radish/utils.py
@@ -24,7 +24,7 @@ from radish import pick
 
 @pick
 def create_lookup_v(remote):
-    g = traversal().withRemote(remote)
+    g = traversal().with_(remote)
 
     # hold a map of name/vertex for use in asserting results
     return g.V().group().by('name').by(__.tail()).next()
@@ -32,7 +32,7 @@ def create_lookup_v(remote):
 
 @pick
 def create_lookup_e(remote):
-    g = traversal().withRemote(remote)
+    g = traversal().with_(remote)
 
     # hold a map of the "name"/edge for use in asserting results - "name" in this context is in the form of
     # outgoingV-label->incomingV
@@ -43,7 +43,7 @@ def create_lookup_e(remote):
 
 @pick
 def create_lookup_vp(remote):
-    g = traversal().withRemote(remote)
+    g = traversal().with_(remote)
 
     # hold a map of the "name"/vertexproperty for use in asserting results - "name" in this context is in the form of
     # vertexName-propName->propVal where the propVal must be typed according to the gherkin spec. note that the toy

--- a/gremlin-python/src/main/python/tests/driver/test_client.py
+++ b/gremlin-python/src/main/python/tests/driver/test_client.py
@@ -312,7 +312,7 @@ def test_multi_thread_pool(client):
     assert results[3][0][0].object == 6
 
 def test_client_bytecode_with_short(client):
-    g = Graph().traversal()
+    g = GraphTraversalSource(Graph(), TraversalStrategies())
     t = g.V().has('age', short(16)).count()
     message = RequestMessage('traversal', 'bytecode', {'gremlin': t.bytecode, 'aliases': {'g': 'gmodern'}})
     result_set = client.submit(message)

--- a/gremlin-python/src/main/python/tests/driver/test_client.py
+++ b/gremlin-python/src/main/python/tests/driver/test_client.py
@@ -25,7 +25,8 @@ from gremlin_python.driver import serializer
 from gremlin_python.driver.client import Client
 from gremlin_python.driver.protocol import GremlinServerError
 from gremlin_python.driver.request import RequestMessage
-from gremlin_python.process.graph_traversal import __
+from gremlin_python.process.graph_traversal import __, GraphTraversalSource
+from gremlin_python.process.traversal import TraversalStrategies
 from gremlin_python.process.strategies import OptionsStrategy
 from gremlin_python.structure.graph import Graph, Vertex
 from gremlin_python.driver.aiohttp.transport import AiohttpTransport
@@ -39,7 +40,7 @@ test_no_auth_url = gremlin_server_url.format(45940)
 
 
 def test_connection(connection):
-    g = Graph().traversal()
+    g = GraphTraversalSource(Graph(), TraversalStrategies())
     t = g.V()
     message = RequestMessage('traversal', 'bytecode', {'gremlin': t.bytecode, 'aliases': {'g': 'gmodern'}})
     results_set = connection.write(message).result()
@@ -192,7 +193,7 @@ def test_client_gremlin(client):
 
 
 def test_client_bytecode(client):
-    g = Graph().traversal()
+    g = GraphTraversalSource(Graph(), TraversalStrategies())
     t = g.V()
     message = RequestMessage('traversal', 'bytecode', {'gremlin': t.bytecode, 'aliases': {'g': 'gmodern'}})
     result_set = client.submit(message)
@@ -202,7 +203,7 @@ def test_client_bytecode(client):
 def test_client_bytecode_options(client):
     # smoke test to validate serialization of OptionsStrategy. no way to really validate this from an integration
     # test perspective because there's no way to access the internals of the strategy via bytecode
-    g = Graph().traversal()
+    g = GraphTraversalSource(Graph(), TraversalStrategies())
     t = g.withStrategies(OptionsStrategy(options={"x": "test", "y": True})).V()
     message = RequestMessage('traversal', 'bytecode', {'gremlin': t.bytecode, 'aliases': {'g': 'gmodern'}})
     result_set = client.submit(message)
@@ -215,7 +216,7 @@ def test_client_bytecode_options(client):
 
 
 def test_iterate_result_set(client):
-    g = Graph().traversal()
+    g = GraphTraversalSource(Graph(), TraversalStrategies())
     t = g.V()
     message = RequestMessage('traversal', 'bytecode', {'gremlin': t.bytecode, 'aliases': {'g': 'gmodern'}})
     result_set = client.submit(message)
@@ -226,7 +227,7 @@ def test_iterate_result_set(client):
 
 
 def test_client_async(client):
-    g = Graph().traversal()
+    g = GraphTraversalSource(Graph(), TraversalStrategies())
     t = g.V()
     message = RequestMessage('traversal', 'bytecode', {'gremlin': t.bytecode, 'aliases': {'g': 'gmodern'}})
     future = client.submit_async(message)
@@ -237,7 +238,7 @@ def test_client_async(client):
 def test_connection_share(client):
     # Overwrite fixture with pool_size=1 client
     client = Client(test_no_auth_url, 'gmodern', pool_size=1)
-    g = Graph().traversal()
+    g = GraphTraversalSource(Graph(), TraversalStrategies())
     t = g.V()
     message = RequestMessage('traversal', 'bytecode', {'gremlin': t.bytecode, 'aliases': {'g': 'gmodern'}})
     message2 = RequestMessage('traversal', 'bytecode', {'gremlin': t.bytecode, 'aliases': {'g': 'gmodern'}})
@@ -254,7 +255,7 @@ def test_connection_share(client):
 
 
 def test_multi_conn_pool(client):
-    g = Graph().traversal()
+    g = GraphTraversalSource(Graph(), TraversalStrategies())
     t = g.V()
     message = RequestMessage('traversal', 'bytecode', {'gremlin': t.bytecode, 'aliases': {'g': 'gmodern'}})
     message2 = RequestMessage('traversal', 'bytecode', {'gremlin': t.bytecode, 'aliases': {'g': 'gmodern'}})
@@ -271,7 +272,7 @@ def test_multi_conn_pool(client):
 
 
 def test_multi_thread_pool(client):
-    g = Graph().traversal()
+    g = GraphTraversalSource(Graph(), TraversalStrategies())
     traversals = [g.V(),
                   g.V().count(),
                   g.E(),
@@ -321,7 +322,7 @@ def test_client_bytecode_with_short(client):
     assert len(results) == 1
 
 def test_client_bytecode_with_long(client):
-    g = Graph().traversal()
+    g = GraphTraversalSource(Graph(), TraversalStrategies())
     t = g.V().has('age', long(851401972585122)).count()
     message = RequestMessage('traversal', 'bytecode', {'gremlin': t.bytecode, 'aliases': {'g': 'gmodern'}})
     result_set = client.submit(message)
@@ -332,7 +333,7 @@ def test_client_bytecode_with_long(client):
 
 
 def test_client_bytecode_with_bigint(client):
-    g = Graph().traversal()
+    g = GraphTraversalSource(Graph(), TraversalStrategies())
     t = g.V().has('age', bigint(0x1000_0000_0000_0000_0000)).count()
     message = RequestMessage('traversal', 'bytecode', {'gremlin': t.bytecode, 'aliases': {'g': 'gmodern'}})
     result_set = client.submit(message)
@@ -373,7 +374,7 @@ def test_client_pool_in_session(client):
 
 
 def test_big_result_set(client):
-    g = Graph().traversal()
+    g = GraphTraversalSource(Graph(), TraversalStrategies())
     t = g.inject(1).repeat(__.addV('person').property('name', __.loops())).times(20000).count()
     message = RequestMessage('traversal', 'bytecode', {'gremlin': t.bytecode, 'aliases': {'g': 'g'}})
     result_set = client.submit(message)
@@ -416,7 +417,7 @@ def test_big_result_set(client):
 
 
 def test_big_result_set_secure(authenticated_client):
-    g = Graph().traversal()
+    g = GraphTraversalSource(Graph(), TraversalStrategies())
     t = g.inject(1).repeat(__.addV('person').property('name', __.loops())).times(20000).count()
     message = RequestMessage('traversal', 'bytecode', {'gremlin': t.bytecode, 'aliases': {'g': 'g'}})
     result_set = authenticated_client.submit(message)
@@ -495,7 +496,7 @@ def test_client_custom_valid_request_id_script_string(client):
 
 def test_client_custom_invalid_request_id_graphson_bytecode(client):
     client = Client(test_no_auth_url, 'gmodern', message_serializer=serializer.GraphSONSerializersV3d0())
-    query = Graph().traversal().V().bytecode
+    query = GraphTraversalSource(Graph(), TraversalStrategies()).V().bytecode
     try:
         client.submit(query, request_options={"requestId":"malformed"}).all().result()
     except Exception as ex:
@@ -504,7 +505,7 @@ def test_client_custom_invalid_request_id_graphson_bytecode(client):
 
 def test_client_custom_invalid_request_id_graphbinary_bytecode(client):
     client = Client(test_no_auth_url, 'gmodern', message_serializer=serializer.GraphBinarySerializersV1())
-    query = Graph().traversal().V().bytecode
+    query = GraphTraversalSource(Graph(), TraversalStrategies()).V().bytecode
     try:
         client.submit(query, request_options={"requestId":"malformed"}).all().result()
     except Exception as ex:
@@ -512,5 +513,5 @@ def test_client_custom_invalid_request_id_graphbinary_bytecode(client):
 
 
 def test_client_custom_valid_request_id_bytecode(client):
-    query = Graph().traversal().V().bytecode
+    query = GraphTraversalSource(Graph(), TraversalStrategies()).V().bytecode
     assert len(client.submit(query).all().result()) == 6

--- a/gremlin-python/src/main/python/tests/driver/test_driver_remote_connection.py
+++ b/gremlin-python/src/main/python/tests/driver/test_driver_remote_connection.py
@@ -43,7 +43,7 @@ test_no_auth_url = gremlin_server_url.format(45940)
 class TestDriverRemoteConnection(object):
     def test_traversals(self, remote_connection):
         statics.load_statics(globals())
-        g = traversal().withRemote(remote_connection)
+        g = traversal().with_(remote_connection)
 
         assert long(6) == g.V().count().toList()[0]
         # #
@@ -131,7 +131,7 @@ class TestDriverRemoteConnection(object):
     def test_lambda_traversals(self, remote_connection):
         statics.load_statics(globals())
         assert "remoteconnection[{},gmodern]".format(test_no_auth_url) == str(remote_connection)
-        g = traversal().withRemote(remote_connection)
+        g = traversal().with_(remote_connection)
 
         assert 24.0 == g.withSack(1.0, lambda: ("x -> x + 1", "gremlin-groovy")).V().both().sack().sum_().next()
         assert 24.0 == g.withSack(lambda: ("{1.0d}", "gremlin-groovy"), lambda: ("x -> x + 1", "gremlin-groovy")).V().both().sack().sum_().next()
@@ -141,7 +141,7 @@ class TestDriverRemoteConnection(object):
 
     def test_iteration(self, remote_connection):
         statics.load_statics(globals())
-        g = traversal().withRemote(remote_connection)
+        g = traversal().with_(remote_connection)
 
         t = g.V().count()
         assert t.hasNext()
@@ -178,7 +178,7 @@ class TestDriverRemoteConnection(object):
 
     def test_strategies(self, remote_connection):
         statics.load_statics(globals())
-        g = traversal().withRemote(remote_connection). \
+        g = traversal().with_(remote_connection). \
             withStrategies(TraversalStrategy("SubgraphStrategy",
                                              {"vertices": __.hasLabel("person"),
                                               "edges": __.hasLabel("created")},
@@ -189,14 +189,14 @@ class TestDriverRemoteConnection(object):
         assert 4 == g.V().filter_(lambda: ("x -> true", "gremlin-groovy")).count().next()
         assert "person" == g.V().label().dedup().next()
         #
-        g = traversal().withRemote(remote_connection). \
+        g = traversal().with_(remote_connection). \
             withStrategies(SubgraphStrategy(vertices=__.hasLabel("person"), edges=__.hasLabel("created")))
         assert 4 == g.V().count().next()
         assert 0 == g.E().count().next()
         assert 1 == g.V().label().dedup().count().next()
         assert "person" == g.V().label().dedup().next()
         #
-        g = traversal().withRemote(remote_connection). \
+        g = traversal().with_(remote_connection). \
             withStrategies(SubgraphStrategy(edges=__.hasLabel("created")))
         assert 6 == g.V().count().next()
         assert 4 == g.E().count().next()
@@ -210,17 +210,17 @@ class TestDriverRemoteConnection(object):
         assert "person" == g.V().label().next()
         assert "marko" == g.V().name.next()
         #
-        g = traversal().withRemote(remote_connection).withComputer()
+        g = traversal().with_(remote_connection).withComputer()
         assert 6 == g.V().count().next()
         assert 6 == g.E().count().next()
         #
-        g = traversal().withRemote(remote_connection).withStrategies(SeedStrategy(12345))
+        g = traversal().with_(remote_connection).withStrategies(SeedStrategy(12345))
         shuffledResult = g.V().values("name").order().by(Order.shuffle).toList()
         assert shuffledResult == g.V().values("name").order().by(Order.shuffle).toList()
         assert shuffledResult == g.V().values("name").order().by(Order.shuffle).toList()
         assert shuffledResult == g.V().values("name").order().by(Order.shuffle).toList()
         #
-        g = traversal().withRemote(remote_connection). \
+        g = traversal().with_(remote_connection). \
             withStrategies(ReservedKeysVerificationStrategy(throw_exception=True))
         try:
             g.addV("person").property("id", "please-don't-use-id").iterate()
@@ -228,7 +228,7 @@ class TestDriverRemoteConnection(object):
         except GremlinServerError as gse:
             assert gse.status_code == 500
         #
-        g = traversal().withRemote(remote_connection).with_("x", True).with_('evaluationTimeout', 10)
+        g = traversal().with_(remote_connection).with_("x", True).with_('evaluationTimeout', 10)
         try:
             g.inject(1).sideEffect(lambda: ("Thread.sleep(1000)", "gremlin-groovy")).iterate()
             assert False
@@ -236,7 +236,7 @@ class TestDriverRemoteConnection(object):
             assert gse.status_code == 598
 
     def test_close_sessions(self, remote_transaction_connection):
-        g = traversal().withRemote(remote_transaction_connection)
+        g = traversal().with_(remote_transaction_connection)
         tx = g.tx()
         gtx = tx.begin()
         # session created for new transaction
@@ -278,7 +278,7 @@ class TestDriverRemoteConnection(object):
             assert "Cannot rollback a transaction that is not started." == str(ex)
 
     def test_clone(self, remote_connection):
-        g = traversal().withRemote(remote_connection)
+        g = traversal().with_(remote_connection)
         t = g.V().both()
         assert 12 == len(t.toList())
         assert 5 == t.clone().limit(5).count().next()
@@ -286,7 +286,7 @@ class TestDriverRemoteConnection(object):
 
     def test_authenticated(self, remote_connection_authenticated):
         statics.load_statics(globals())
-        g = traversal().withRemote(remote_connection_authenticated)
+        g = traversal().with_(remote_connection_authenticated)
 
         assert long(6) == g.V().count().toList()[0]
 

--- a/gremlin-python/src/main/python/tests/driver/test_driver_remote_connection_http.py
+++ b/gremlin-python/src/main/python/tests/driver/test_driver_remote_connection_http.py
@@ -39,7 +39,7 @@ test_no_auth_http_url = gremlin_server_url_http.format(45940)
 class TestDriverRemoteConnectionHttp(object):
     def test_traversals(self, remote_connection_http):
         statics.load_statics(globals())
-        g = traversal().withRemote(remote_connection_http)
+        g = traversal().with_(remote_connection_http)
 
         assert long(6) == g.V().count().toList()[0]
         # #
@@ -114,7 +114,7 @@ class TestDriverRemoteConnectionHttp(object):
 
     def test_iteration(self, remote_connection_http):
         statics.load_statics(globals())
-        g = traversal().withRemote(remote_connection_http)
+        g = traversal().with_(remote_connection_http)
 
         t = g.V().count()
         assert t.hasNext()
@@ -152,7 +152,7 @@ class TestDriverRemoteConnectionHttp(object):
     def test_lambda_traversals(self, remote_connection_http):
         statics.load_statics(globals())
         assert "remoteconnection[{},gmodern]".format(test_no_auth_http_url) == str(remote_connection_http)
-        g = traversal().withRemote(remote_connection_http)
+        g = traversal().with_(remote_connection_http)
 
         assert 24.0 == g.withSack(1.0, lambda: ("x -> x + 1", "gremlin-groovy")).V().both().sack().sum_().next()
         assert 24.0 == g.withSack(lambda: ("{1.0d}", "gremlin-groovy"),
@@ -164,7 +164,7 @@ class TestDriverRemoteConnectionHttp(object):
 
     def test_strategies(self, remote_connection_http):
         statics.load_statics(globals())
-        g = traversal().withRemote(remote_connection_http). \
+        g = traversal().with_(remote_connection_http). \
             withStrategies(TraversalStrategy("SubgraphStrategy",
                                              {"vertices": __.hasLabel("person"),
                                               "edges": __.hasLabel("created")},
@@ -175,14 +175,14 @@ class TestDriverRemoteConnectionHttp(object):
         assert 4 == g.V().filter_(lambda: ("x -> true", "gremlin-groovy")).count().next()
         assert "person" == g.V().label().dedup().next()
         #
-        g = traversal().withRemote(remote_connection_http). \
+        g = traversal().with_(remote_connection_http). \
             withStrategies(SubgraphStrategy(vertices=__.hasLabel("person"), edges=__.hasLabel("created")))
         assert 4 == g.V().count().next()
         assert 0 == g.E().count().next()
         assert 1 == g.V().label().dedup().count().next()
         assert "person" == g.V().label().dedup().next()
         #
-        g = traversal().withRemote(remote_connection_http). \
+        g = traversal().with_(remote_connection_http). \
             withStrategies(SubgraphStrategy(edges=__.hasLabel("created")))
         assert 6 == g.V().count().next()
         assert 4 == g.E().count().next()
@@ -196,18 +196,18 @@ class TestDriverRemoteConnectionHttp(object):
         assert "person" == g.V().label().next()
         assert "marko" == g.V().name.next()
         #
-        g = traversal().withRemote(remote_connection_http).withComputer()
+        g = traversal().with_(remote_connection_http).withComputer()
         assert 6 == g.V().count().next()
         assert 6 == g.E().count().next()
         #
-        g = traversal().withRemote(remote_connection_http).withStrategies(SeedStrategy(12345))
+        g = traversal().with_(remote_connection_http).withStrategies(SeedStrategy(12345))
         shuffledResult = g.V().values("name").order().by(Order.shuffle).toList()
         assert shuffledResult == g.V().values("name").order().by(Order.shuffle).toList()
         assert shuffledResult == g.V().values("name").order().by(Order.shuffle).toList()
         assert shuffledResult == g.V().values("name").order().by(Order.shuffle).toList()
 
     def test_clone(self, remote_connection_http):
-        g = traversal().withRemote(remote_connection_http)
+        g = traversal().with_(remote_connection_http)
         t = g.V().both()
         assert 12 == len(t.toList())
         assert 5 == t.clone().limit(5).count().next()
@@ -229,7 +229,7 @@ class TestDriverRemoteConnectionHttp(object):
     
     def test_authenticated(self, remote_connection_http_authenticated):
         statics.load_statics(globals())
-        g = traversal().withRemote(remote_connection_http_authenticated)
+        g = traversal().with_(remote_connection_http_authenticated)
 
         assert long(6) == g.V().count().toList()[0]
     """

--- a/gremlin-python/src/main/python/tests/driver/test_driver_remote_connection_threaded.py
+++ b/gremlin-python/src/main/python/tests/driver/test_driver_remote_connection_threaded.py
@@ -64,7 +64,7 @@ def _executor(q, conn):
         close = True
         conn = DriverRemoteConnection(test_no_auth_url, 'gmodern', pool_size=4)
     try:
-        g = traversal().withRemote(conn)
+        g = traversal().with_(conn)
         future = g.V().promise()
         t = future.result()
         assert len(t.toList()) == 6
@@ -80,7 +80,7 @@ def _executor(q, conn):
 def handle_request():
     try:
         remote_connection = DriverRemoteConnection(test_no_auth_url, "g")
-        g = traversal().withRemote(remote_connection)
+        g = traversal().with_(remote_connection)
         g.V().limit(1).toList()
         remote_connection.close()
         return True

--- a/gremlin-python/src/main/python/tests/process/test_dsl.py
+++ b/gremlin-python/src/main/python/tests/process/test_dsl.py
@@ -22,7 +22,7 @@ from gremlin_python.process.traversal import Bytecode, P
 from gremlin_python.process.graph_traversal import (
     GraphTraversalSource, GraphTraversal)
 from gremlin_python.process.graph_traversal import __ as AnonymousTraversal
-from gremlin_python.structure.graph import Graph
+from gremlin_python.process.anonymous_traversal import traversal
 
 __author__ = 'David M. Brown (davebshow@gmail.com)'
 
@@ -71,7 +71,7 @@ class SocialTraversalSource(GraphTraversalSource):
 
 
 def test_dsl(remote_connection):
-    social = Graph().traversal(SocialTraversalSource).withRemote(remote_connection)
+    social = traversal(SocialTraversalSource).with_(remote_connection)
     assert social.persons("marko").knows("josh").next()
     assert social.persons("marko").youngestFriendsAge().next() == 27
     assert social.persons().count().next() == 4

--- a/gremlin-python/src/main/python/tests/process/test_strategies.py
+++ b/gremlin-python/src/main/python/tests/process/test_strategies.py
@@ -19,14 +19,14 @@
 
 __author__ = 'Marko A. Rodriguez (http://markorodriguez.com)'
 
-from gremlin_python.structure.graph import Graph
+from gremlin_python.process.anonymous_traversal import traversal
 from gremlin_python.process.strategies import *
 from gremlin_python.process.graph_traversal import __
 
 
 class TestTraversalStrategies(object):
     def test_singletons(self):
-        g = Graph().traversal()
+        g = traversal().with_(None)
         bytecode = g.withStrategies(ReadOnlyStrategy()).bytecode
         assert 1 == len(bytecode.source_instructions)
         assert 2 == len(bytecode.source_instructions[0])
@@ -78,7 +78,7 @@ class TestTraversalStrategies(object):
         assert 1 == len(bytecode.step_instructions)
         assert "V" == bytecode.step_instructions[0][0]
         ###
-        g = Graph().traversal()
+        g = traversal().with_(None)
         bytecode = g.with_("x", "test").with_("y").bytecode
         assert 1 == len(bytecode.source_instructions)
         assert 2 == len(bytecode.source_instructions[0])
@@ -90,7 +90,7 @@ class TestTraversalStrategies(object):
         assert strategy.configuration["y"]
 
     def test_configurable(self):
-        g = Graph().traversal()
+        g = traversal().with_(None)
         bytecode = g.withStrategies(MatchAlgorithmStrategy("greedy")).bytecode
         assert 1 == len(bytecode.source_instructions)
         assert 2 == len(bytecode.source_instructions[0])

--- a/gremlin-python/src/main/python/tests/process/test_translator.py
+++ b/gremlin-python/src/main/python/tests/process/test_translator.py
@@ -31,7 +31,7 @@ from datetime import datetime
 class TestTranslator(object):
 
     def test_translations(self):
-        g = traversal().withGraph(Graph())
+        g = traversal().with_(None)
 
         tests = list()
         # 0
@@ -450,7 +450,7 @@ class TestTranslator(object):
 
     def test_constructor(self):
         tlr = Translator().of('g')
-        g = traversal().withGraph(Graph())
+        g = traversal().with_(None)
         assert tlr.translate(g.V().bytecode) == "g.V()"
 
     def test_source_name(self):

--- a/gremlin-python/src/main/python/tests/process/test_traversal.py
+++ b/gremlin-python/src/main/python/tests/process/test_traversal.py
@@ -37,7 +37,7 @@ anonymous_url = gremlin_server_url.format(45940)
 
 class TestTraversal(object):
     def test_bytecode(self):
-        g = traversal().withGraph(Graph())
+        g = traversal().with_(None)
         bytecode = g.V().out("created").bytecode
         assert 0 == len(bytecode.bindings.keys())
         assert 0 == len(bytecode.source_instructions)
@@ -111,7 +111,7 @@ class TestTraversal(object):
         assert 0 == len(bytecode.step_instructions)
 
     def test_clone_traversal(self):
-        g = traversal().withGraph(Graph())
+        g = traversal().with_(None)
         original = g.V().out("created")
         clone = original.clone().out("knows")
         cloneClone = clone.clone().out("created")
@@ -128,7 +128,7 @@ class TestTraversal(object):
         assert 4 == len(cloneClone.bytecode.step_instructions)
 
     def test_no_sugar_for_magic_methods(self):
-        g = traversal().withGraph(Graph())
+        g = traversal().with_(None)
 
         t = g.V().age
         assert 2 == len(t.bytecode.step_instructions)
@@ -141,7 +141,7 @@ class TestTraversal(object):
                 err) == 'Python magic methods or keys starting with double underscore cannot be used for Gremlin sugar - prefer values(__len__)'
 
     def test_enforce_anonymous_child_traversal(self):
-        g = traversal().withGraph(Graph())
+        g = traversal().with_(None)
         g.V(0).addE("self").to(__.V(1))
 
         try:
@@ -152,7 +152,7 @@ class TestTraversal(object):
 
     def test_transaction_commit(self, remote_transaction_connection):
         # Start a transaction traversal.
-        g = traversal().withRemote(remote_transaction_connection)
+        g = traversal().with_(remote_transaction_connection)
         start_count = g.V().count().next()
         tx = g.tx()
 
@@ -175,7 +175,7 @@ class TestTraversal(object):
 
     def test_transaction_rollback(self, remote_transaction_connection):
         # Start a transaction traversal.
-        g = traversal().withRemote(remote_transaction_connection)
+        g = traversal().with_(remote_transaction_connection)
         start_count = g.V().count().next()
         tx = g.tx()
 
@@ -198,7 +198,7 @@ class TestTraversal(object):
 
     def test_transaction_no_begin(self, remote_transaction_connection):
         # Start a transaction traversal.
-        g = traversal().withRemote(remote_transaction_connection)
+        g = traversal().with_(remote_transaction_connection)
         tx = g.tx()
 
         # Except transaction to not be open until begin is called.
@@ -249,7 +249,7 @@ class TestTraversal(object):
 
     def test_multi_commit_transaction(self, remote_transaction_connection):
         # Start a transaction traversal.
-        g = traversal().withRemote(remote_transaction_connection)
+        g = traversal().with_(remote_transaction_connection)
         start_count = g.V().count().next()
 
         # Create two transactions.
@@ -279,7 +279,7 @@ class TestTraversal(object):
 
     def test_multi_rollback_transaction(self, remote_transaction_connection):
         # Start a transaction traversal.
-        g = traversal().withRemote(remote_transaction_connection)
+        g = traversal().with_(remote_transaction_connection)
         start_count = g.V().count().next()
 
         # Create two transactions.
@@ -309,7 +309,7 @@ class TestTraversal(object):
 
     def test_multi_commit_and_rollback(self, remote_transaction_connection):
         # Start a transaction traversal.
-        g = traversal().withRemote(remote_transaction_connection)
+        g = traversal().with_(remote_transaction_connection)
         start_count = g.V().count().next()
 
         # Create two transactions.
@@ -339,7 +339,7 @@ class TestTraversal(object):
 
     def test_transaction_close_tx(self):
         remote_conn = create_connection_to_gtx()
-        g = traversal().withRemote(remote_conn)
+        g = traversal().with_(remote_conn)
 
         drop_graph_check_count(g)
 
@@ -367,14 +367,14 @@ class TestTraversal(object):
         verify_gtx_closed(gtx2)
 
         remote_conn = create_connection_to_gtx()
-        g = traversal().withRemote(remote_conn)
+        g = traversal().with_(remote_conn)
         assert g.V().count().next() == 0
 
         drop_graph_check_count(g)
 
     def test_transaction_close_tx_from_parent(self):
         remote_conn = create_connection_to_gtx()
-        g = traversal().withRemote(remote_conn)
+        g = traversal().with_(remote_conn)
 
         drop_graph_check_count(g)
 
@@ -402,7 +402,7 @@ class TestTraversal(object):
         verify_gtx_closed(gtx2)
 
         remote_conn = create_connection_to_gtx()
-        g = traversal().withRemote(remote_conn)
+        g = traversal().with_(remote_conn)
         assert g.V().count().next() == 0
 
         drop_graph_check_count(g)

--- a/gremlin-python/src/main/python/tests/structure/io/test_functionalityio.py
+++ b/gremlin-python/src/main/python/tests/structure/io/test_functionalityio.py
@@ -21,12 +21,12 @@ import datetime
 import uuid
 
 from gremlin_python.driver.serializer import GraphSONSerializersV2d0, GraphBinarySerializersV1
-from gremlin_python.structure.graph import Graph
+from gremlin_python.process.anonymous_traversal import traversal
 from gremlin_python.statics import *
 
 
 def test_vertex(remote_connection):
-    g = Graph().traversal().with_remote(remote_connection)
+    g = traversal().with_(remote_connection)
     vertex = g.V(1).next()
     assert vertex.id == 1
     assert vertex.label == 'person'
@@ -38,7 +38,7 @@ def test_vertex(remote_connection):
 
 
 def test_vertex_without_properties(remote_connection):
-    g = Graph().traversal().with_remote(remote_connection)
+    g = traversal().with_(remote_connection)
     vertex = g.with_('materializeProperties', 'tokens').V(1).next()
     assert vertex.id == 1
     assert vertex.label == 'person'
@@ -47,7 +47,7 @@ def test_vertex_without_properties(remote_connection):
 
 
 def test_edge(remote_connection):
-    g = Graph().traversal().with_remote(remote_connection)
+    g = traversal().with_(remote_connection)
     edge = g.E(7).next()
     assert edge.id == 7
     assert edge.label == 'knows'
@@ -57,7 +57,7 @@ def test_edge(remote_connection):
 
 
 def test_edge_without_properties(remote_connection):
-    g = Graph().traversal().with_remote(remote_connection)
+    g = traversal().with_(remote_connection)
     edge = g.with_('materializeProperties', 'tokens').E(7).next()
     assert edge.id == 7
     assert edge.label == 'knows'
@@ -66,7 +66,7 @@ def test_edge_without_properties(remote_connection):
 
 
 def test_vertex_vertex_properties(remote_connection_crew):
-    g = Graph().traversal().withRemote(remote_connection_crew)
+    g = traversal().with_(remote_connection_crew)
     vertex = g.V(7).next()
     assert vertex.id == 7
     assert vertex.label == 'person'
@@ -81,7 +81,7 @@ def test_vertex_vertex_properties(remote_connection_crew):
 
 
 def test_timestamp(remote_connection):
-    g = Graph().traversal().withRemote(remote_connection)
+    g = traversal().with_(remote_connection)
     ts = timestamp(1481750076295 / 1000)
     resp = g.addV('test_vertex').property('ts', ts)
     resp = resp.toList()
@@ -95,7 +95,7 @@ def test_timestamp(remote_connection):
 
 
 def test_datetime(remote_connection):
-    g = Graph().traversal().withRemote(remote_connection)
+    g = traversal().with_(remote_connection)
     dt = datetime.datetime.utcfromtimestamp(1481750076295 / 1000)
     resp = g.addV('test_vertex').property('dt', dt).toList()
     vid = resp[0].id
@@ -108,7 +108,7 @@ def test_datetime(remote_connection):
 
 
 def test_uuid(remote_connection):
-    g = Graph().traversal().withRemote(remote_connection)
+    g = traversal().with_(remote_connection)
     uid = uuid.UUID("41d2e28a-20a4-4ab0-b379-d810dede3786")
     resp = g.addV('test_vertex').property('uuid', uid).toList()
     vid = resp[0].id
@@ -124,7 +124,7 @@ def test_short(remote_connection):
     if not isinstance(remote_connection._client._message_serializer, GraphBinarySerializersV1):
         return
 
-    g = Graph().traversal().withRemote(remote_connection)
+    g = traversal().with_(remote_connection)
     num = short(1111)
     resp = g.addV('test_vertex').property('short', num).toList()
     vid = resp[0].id
@@ -140,7 +140,7 @@ def test_bigint_positive(remote_connection):
     if not isinstance(remote_connection._client._message_serializer, GraphBinarySerializersV1):
         return
 
-    g = Graph().traversal().withRemote(remote_connection)
+    g = traversal().with_(remote_connection)
     big = bigint(0x1000_0000_0000_0000_0000)
     resp = g.addV('test_vertex').property('bigint', big).toList()
     vid = resp[0].id
@@ -156,7 +156,7 @@ def test_bigint_negative(remote_connection):
     if not isinstance(remote_connection._client._message_serializer, GraphBinarySerializersV1):
         return
 
-    g = Graph().traversal().withRemote(remote_connection)
+    g = traversal().with_(remote_connection)
     big = bigint(-0x1000_0000_0000_0000_0000)
     resp = g.addV('test_vertex').property('bigint', big).toList()
     vid = resp[0].id
@@ -172,7 +172,7 @@ def test_bigdecimal(remote_connection):
     if not isinstance(remote_connection._client._message_serializer, GraphBinarySerializersV1):
         return
 
-    g = Graph().traversal().withRemote(remote_connection)
+    g = traversal().with_(remote_connection)
     bigdecimal = BigDecimal(101, 235)
     resp = g.addV('test_vertex').property('bigdecimal', bigdecimal).toList()
     vid = resp[0].id
@@ -187,7 +187,7 @@ def test_bigdecimal(remote_connection):
 
 def test_odd_bits(remote_connection):
     if not isinstance(remote_connection._client._message_serializer, GraphSONSerializersV2d0):
-        g = Graph().traversal().withRemote(remote_connection)
+        g = traversal().with_(remote_connection)
         char_lower = str.__new__(SingleChar, chr(78))
         resp = g.addV('test_vertex').property('char_lower', char_lower).toList()
         vid = resp[0].id

--- a/gremlin-python/src/main/python/tests/structure/io/test_graphsonV2d0.py
+++ b/gremlin-python/src/main/python/tests/structure/io/test_graphsonV2d0.py
@@ -35,6 +35,7 @@ import gremlin_python.structure.io.graphsonV2d0
 from gremlin_python.process.traversal import P, Merge, Operator, Order, Barrier, Direction
 from gremlin_python.process.strategies import SubgraphStrategy
 from gremlin_python.process.graph_traversal import __
+from gremlin_python.process.anonymous_traversal import traversal
 
 
 class TestGraphSONReader:
@@ -493,7 +494,7 @@ class TestFunctionalGraphSONIO:
     """Functional IO tests"""
 
     def test_timestamp(self, remote_connection_graphsonV2):
-        g = Graph().traversal().withRemote(remote_connection_graphsonV2)
+        g = traversal().with_(remote_connection_graphsonV2)
         ts = timestamp(1481750076295 / 1000)
         resp = g.addV('test_vertex').property('ts', ts)
         resp = resp.toList()
@@ -508,7 +509,7 @@ class TestFunctionalGraphSONIO:
             g.V(vid).drop().iterate()
 
     def test_datetime(self, remote_connection_graphsonV2):
-        g = Graph().traversal().withRemote(remote_connection_graphsonV2)
+        g = traversal().with_(remote_connection_graphsonV2)
         dt = datetime.datetime.utcfromtimestamp(1481750076295 / 1000)
         resp = g.addV('test_vertex').property('dt', dt).toList()
         vid = resp[0].id
@@ -522,7 +523,7 @@ class TestFunctionalGraphSONIO:
             g.V(vid).drop().iterate()
 
     def test_uuid(self, remote_connection_graphsonV2):
-        g = Graph().traversal().withRemote(remote_connection_graphsonV2)
+        g = traversal().with_(remote_connection_graphsonV2)
         uid = uuid.UUID("41d2e28a-20a4-4ab0-b379-d810dede3786")
         resp = g.addV('test_vertex').property('uuid', uid).toList()
         vid = resp[0].id


### PR DESCRIPTION
Replaces withEmbedded() and withRemote() and removes the long deprecated withGraph(). A single unified with() removes the need to check the object being given to the AnonymousTraversalSource to decide which method to use. Can't remember why that split was used in the first place. This should make it easier to explain how to use the AnonymousTraversalSource in the first place, requires a bit less typing and simply streamlines the API.

This is a back port of https://github.com/apache/tinkerpop/pull/2366 from master (4.0) without the CHANGELOG.asciidoc and release-4.x.x.asciidoc changes as there is not yet a place for this content in the back port branch.